### PR TITLE
Make puppet wait for CSR to be signed

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -16,7 +16,8 @@ from uuid import getnode
 
 HOSTNAME  = platform.node()
 HEXMAC    = hex(getnode())
-MAC       = HEXMAC[2:14]
+NOHEXMAC  = HEXMAC[2:]
+MAC       = NOHEXMAC.zfill(13)[0:12]
 
 parser = OptionParser()
 parser.add_option("-s", "--server", dest="sat6_fqdn", help="FQDN of Satellite - omit https://", metavar="SAT6_FQDN")

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -156,7 +156,7 @@ def install_puppet_agent():
   #f.write("server=%s \n" % SAT6_FQDN)
   #f.close()
   print_generic("Running Puppet in noop mode to generate SSL certs")
-  exec_failexit("/usr/bin/puppet agent --test --noop --onetime")
+  exec_failexit("/usr/bin/puppet agent --test --noop --waitforcert 10")
   exec_failexit("/sbin/service puppet restart")
 
 def fully_update_the_box():


### PR DESCRIPTION
This option will make puppet wait for the certificate to be signed before continuing. Else, unless the puppet master is autosigning the CSRs, the script would halt, puppet service would not be started, and packages would not be updated.
