### PR TITLE
add --skip-puppet option

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -25,6 +25,7 @@ parser.add_option("-s", "--server", dest="sat6_fqdn", help="FQDN of Satellite - 
 parser.add_option("-l", "--login", dest="login", default='admin', help="Login user for API Calls", metavar="LOGIN")
 parser.add_option("-p", "--password", dest="password", help="Password for specified user. Will prompt if omitted", metavar="PASSWORD")
 parser.add_option("-a", "--activationkey", dest="activationkey", help="Activation Key to register the system", metavar="ACTIVATIONKEY")
+parser.add_option("-P", "--skip-puppet", dest="no_puppet", action="store_true", default=False, help="Do not install Puppet")
 parser.add_option("-g", "--hostgroup", dest="hostgroup", help="Label of the Hostgroup in Satellite that the host is to be associated with", metavar="HOSTGROUP")
 parser.add_option("-L", "--location", dest="location", default='Default_Location', help="Label of the Location in Satellite that the host is to be associated with", metavar="HOSTGROUP")
 parser.add_option("-o", "--organization", dest="org", default='Default_Organization', help="Label of the Organization in Satellite that the host is to be associated with", metavar="ORG")
@@ -295,5 +296,6 @@ else:
 
 enable_sat_tools()
 install_katello_agent()
-install_puppet_agent()
+if not options.no_puppet:
+  install_puppet_agent()
 fully_update_the_box()


### PR DESCRIPTION
Adding the option to not manage a server with Puppet.
Useful for environments where configuration management is managed by something else.
