### PR TITLE
don't hardcode ptable_id to 7

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -433,7 +433,7 @@ def create_host():
     architecture_id = return_matching_architecture_id(ARCHITECTURE)
     host_id = return_matching_host(FQDN)
     # create the starting json, to be filled below
-    jsondata = json.loads('{"host": {"name": "%s","hostgroup_id": %s,"organization_id": %s,"location_id": %s,"mac":"%s", "domain_id":%s,"architecture_id":%s,"ptable_id":7}}' % (HOSTNAME, myhgid, myorgid, mylocid, MAC, mydomainid, architecture_id))
+    jsondata = json.loads('{"host": {"name": "%s","hostgroup_id": %s,"organization_id": %s,"location_id": %s,"mac":"%s", "domain_id":%s,"architecture_id":%s}}' % (HOSTNAME, myhgid, myorgid, mylocid, MAC, mydomainid, architecture_id))
     # optional parameters
     if options.operatingsystem is not None:
       operatingsystem_id = return_matching_operatingsystem_id(options.operatingsystem)


### PR DESCRIPTION
this was accidentally introduced in 4e1f0ad121eb27a8f09302efb07c800830b0797d

maybe @Rocco83 wants to fix it "properly", but I see no reason why the ptable should not be set on the OS/HG level.
