### PR TITLE
stricter check if machine is subscribed to legacy management

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -397,7 +397,11 @@ def disassociate_host(host_id):
 
 
 def check_rhn_registration():
-    return os.path.exists('/etc/sysconfig/rhn/systemid')
+    if os.path.exists('/etc/sysconfig/rhn/systemid'):
+        retcode = commands.getstatusoutput('rhn-channel -l')[0]
+        return retcode == 0
+    else:
+        return False
 
 
 def get_api_port():


### PR DESCRIPTION
in some cases the machine will have a systemid file but that will be outdated/revoked/whatever, which will result in failures during migration

Signed-off-by: Evgeni Golov evgeni@golov.de
