### PR TITLE
RHEL5 support

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,6 +1,9 @@
 #!/usr/bin/python
 #
-import json
+try:
+    import json
+except ImportError:
+    import simplejson as json
 import getpass
 import urllib2
 import base64

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -21,7 +21,10 @@ from ConfigParser import SafeConfigParser
 
 def get_architecture():
     # May not be safe for anything apart from 32/64 bit OS
-    is_64bit = sys.maxsize > 2 ** 32
+    try:
+        is_64bit = sys.maxsize > 2 ** 32
+    except:
+        is_64bit = platform.architecture()[0] == '64bit'
     if is_64bit:
         return "x86_64"
     else:

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,9 +1,6 @@
 #!/usr/bin/python
 #
-try:
-    import json
-except ImportError:
-    import simplejson as json
+
 import getpass
 import urllib2
 import base64
@@ -462,6 +459,24 @@ def get_api_port():
 
 print "Foreman Bootstrap Script"
 print "This script is designed to register new systems or to migrate an existing system to a Foreman server with Katello"
+
+
+# try to import json or simplejson
+# do it at this point in the code to have our custom print and exec functions available
+try:
+    import json
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        print_warning("Could neither import json nor simplejson, will try to install simplejson and re-import")
+        exec_failexit("yum install -y python-simplejson")
+        try:
+            import simplejson as json
+        except ImportError:
+            print_error("Could not install python-simplejson")
+            sys.exit(1)
+
 
 clean_environment()
 if options.remove:

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -234,13 +234,25 @@ def install_puppet_agent():
     print_generic("Installing the Puppet Agent")
     exec_failexit("/usr/bin/yum -y install puppet")
     exec_failexit("/sbin/chkconfig puppet on")
-    exec_failexit("/usr/bin/puppet config set server %s --section agent" % options.foreman_fqdn)
-    exec_failexit("/usr/bin/puppet config set ca_server %s --section agent" % options.foreman_fqdn)
-    exec_failexit("/usr/bin/puppet config set environment %s --section agent" % puppet_env)
-    # Might need this for RHEL5
-    # f = open("/etc/puppet/puppet.conf","a")
-    # f.write("server=%s \n" % options.foreman_fqdn)
-    # f.close()
+    puppet_conf = open('/etc/puppet/puppet.conf', 'wb')
+    puppet_conf.write("""
+[main]
+vardir = /var/lib/puppet
+logdir = /var/log/puppet
+rundir = /var/run/puppet
+ssldir = \$vardir/ssl
+
+[agent]
+pluginsync      = true
+report          = true
+ignoreschedules = true
+daemon          = false
+ca_server       = %s
+certname        = %s
+environment     = %s
+server          = %s
+""" % (options.foreman_fqdn, FQDN, puppet_env, options.foreman_fqdn))
+    puppet_conf.close()
     print_generic("Running Puppet in noop mode to generate SSL certs")
     print_generic("Visit the UI and approve this certificate via Infrastructure->Capsules")
     print_generic("if auto-signing is disabled")

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -480,7 +480,7 @@ def prepare_rhel5_migration():
     # add to the path if need be
     if _LIBPATH not in sys.path:
         sys.path.append(_LIBPATH)
-        from subscription_manager.migrate import migrate
+    from subscription_manager.migrate import migrate
 
     me = migrate.MigrationEngine()
     me.options.force = True

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -50,9 +50,12 @@ except ImportError:
 if not MAC:
     MAC = "00:00:00:00:00:00"
 
-RELEASE = platform.linux_distribution()[1]
 API_PORT = "443"
 ARCHITECTURE = get_architecture()
+try:
+    RELEASE = platform.linux_distribution()[1]
+except AttributeError:
+    RELEASE = platform.dist()[1]
 
 parser = OptionParser()
 parser.add_option("-s", "--server", dest="foreman_fqdn", help="FQDN of Foreman OR Capsule - omit https://", metavar="foreman_fqdn")

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -482,8 +482,11 @@ def prepare_rhel5_migration():
         sys.path.append(_LIBPATH)
     from subscription_manager.migrate import migrate
 
+    class MEOptions:
+        force = True
+
     me = migrate.MigrationEngine()
-    me.options.force = True
+    me.options = MEOptions()
     subscribed_channels = me.get_subscribed_channels_list()
     me.print_banner(("System is currently subscribed to these RHNClassic Channels:"))
     for channel in subscribed_channels:


### PR DESCRIPTION
this adds support for RHEL5 which is a bit challenging:
- Python 2.4 has no `json` module, thus we try to use `python-simplejson` (and even try to `yum install` it, if it is not available)
- Python 2.4 has no `uuid` module, thus try to get the MAC address from `/sys/class/net` in that case
- Python 2.4 has no `platform.linux_distribution()`, thus try `platform.dist()` in that case. This is not as reliable, but should work.
- Python 2.4 has no `sys.maxsize`, add a workaround.
- Puppet on RHEL5 has no `puppet config set`, so write `puppet.conf` using a simple template instead.
- subscription-manager migration code on RHEL5 is a bit old and outdated, thus "migrate" machines by doing a clean new registration in that case

closes #65
