### PR TITLE
fix ssldir definition in puppet.conf

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -241,7 +241,7 @@ def install_puppet_agent():
 vardir = /var/lib/puppet
 logdir = /var/log/puppet
 rundir = /var/run/puppet
-ssldir = \$vardir/ssl
+ssldir = $vardir/ssl
 
 [agent]
 pluginsync      = true


### PR DESCRIPTION
that was a copy paste error from the kickstart template, which is a shell script and needs to escape "$"

closes: #71
thanks: @peppos
