### PR TITLE
Keeping subscription-manager* packages to latest version

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -177,9 +177,16 @@ def exec_failexit(command):
 
 
 def install_prereqs():
-    print_generic("Installing subscription manager prerequisites")
+    print_generic("Installing or updating subscription manager prerequisites")
     exec_failexit("/usr/bin/yum -y remove subscription-manager-gnome")
-    exec_failexit("/usr/bin/yum -y install subscription-manager subscription-manager-migration-*")
+    if os.path.exists('/usr/sbin/subscription-manager'):
+        exec_failexit("/usr/bin/yum -y update subscription-manager")
+    else:
+        exec_failexit("/usr/bin/yum -y install subscription-manager")
+    if os.path.exists('/usr/sbin/rhn-migrate-classic-to-rhsm'):
+        exec_failexit("/usr/bin/yum -y update subscription-manager-migration-*")
+    else:
+        exec_failexit("/usr/bin/yum -y install subscription-manager-migration-*")
     exec_failexit("/usr/bin/yum -y update yum openssl")
 
 


### PR DESCRIPTION
When subscription-manager-migration\* packages are not latest migration can fail with errors as below, this patch checks if packages installed, if yes then updates those,

[ERROR], [2016-07-11 12:22:06], EXITING: [/usr/sbin/rhn-migrate-classic-to-rhsm --org Some_Org --activation-key some_ak  --destination-url=https://server.example.com:443/rhsm --legacy-user 'user' --legacy-password 'user-pass' --force] failed to execute properly.
Usage: rhn-migrate-classic-to-rhsm [OPTIONS]
