### PR TITLE
Fixed unassigned 'e' variable causing false Python Exception when using verbose option

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -310,7 +310,7 @@ def call_api(url, data=None, method='GET'):
     try:
         request = urllib2.Request(url)
         if options.verbose:
-            print 'error: %s - url: %s' % [e, url]
+            print 'url: %s' % url
             print 'method: %s' % method
             print 'data: %s' % json.dumps(data, sort_keys=False, indent=2)
         base64string = base64.encodestring('%s:%s' % (options.login, options.password)).strip()


### PR DESCRIPTION
Fixed the issue when using the verbose option caused a local variable 'e' referenced before assignment

``` bash
[RUNNING], [2016-09-09 17:06:41], [rpm -Uvh http://boosat62.usersys.redhat.com/pub/katello-ca-consumer-latest.noarch.rpm] 
Retrieving http://boosat62.usersys.redhat.com/pub/katello-ca-consumer-latest.noarch.rpm
Preparing...                ##################################################
katello-ca-consumer-boosat62##################################################
[SUCCESS], [2016-09-09 17:06:47], [rpm -Uvh http://boosat62.usersys.redhat.com/pub/katello-ca-consumer-latest.noarch.rpm], completed successfully.

FATAL Error - local variable 'e' referenced before assignment
```
