### PR TITLE
Install Foreman's SSH key for remote execution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,4 +130,6 @@ Options:
   --unmanaged           Add the server as unmanaged. Useful to skip
                         provisioning dependencies.
   --rex                 Install Foreman's SSH key for remote execution.
+  --rex-user=REMOTE_EXEC_USER
+                        Local user used by Foreman's remote execution feature.
 ~~~

--- a/README.md
+++ b/README.md
@@ -129,4 +129,5 @@ Options:
                         Remove old Red Hat Network Packages
   --unmanaged           Add the server as unmanaged. Useful to skip
                         provisioning dependencies.
+  --rex                 Install Foreman's SSH key for remote execution.
 ~~~


### PR DESCRIPTION
Install Foreman's SSH key for remote execution.
Default: false. Tested on RHEL7.
