### PR TITLE
Enable subscription-manager yum plugins

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -498,7 +498,6 @@ def disassociate_host(host_id):
 def configure_subscription_manager():
     configparser = SafeConfigParser()
     configparser.read('/etc/yum/pluginconf.d/product-id.conf')
-    configparser.get('main', 'enabled')
     if configparser.get('main','enabled') == '0':
       print_generic("Product-id yum plugin was disabled. Enabling...")
       configparser.set('main', 'enabled', '1')
@@ -507,7 +506,6 @@ def configure_subscription_manager():
 
     configparser = SafeConfigParser()
     configparser.read('/etc/yum/pluginconf.d/subscription-manager.conf')
-    configparser.get('main', 'enabled')
     if configparser.get('main','enabled') == '0':
       print_generic("subscription-manager yum plugin was disabled. Enabling...")
       configparser.set('main', 'enabled', '1')

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -496,21 +496,19 @@ def disassociate_host(host_id):
     put_json(myurl)
 
 def configure_subscription_manager():
-    configparser = SafeConfigParser()
-    configparser.read('/etc/yum/pluginconf.d/product-id.conf')
-    if configparser.get('main','enabled') == '0':
+    productidconfig = SafeConfigParser()
+    productidconfig.read('/etc/yum/pluginconf.d/product-id.conf')
+    if productidconfig.get('main','enabled') == '0':
       print_generic("Product-id yum plugin was disabled. Enabling...")
-      configparser.set('main', 'enabled', '1')
-      with open('/etc/yum/pluginconf.d/product-id.conf','w') as configfile:
-        configparser.write(configfile)
-
-    configparser = SafeConfigParser()
-    configparser.read('/etc/yum/pluginconf.d/subscription-manager.conf')
-    if configparser.get('main','enabled') == '0':
+      productidconfig.set('main', 'enabled', '1')
+      productidconfig.write(open('/etc/yum/pluginconf.d/product-id.conf','w')) 
+      
+    submanconfig = SafeConfigParser()
+    submanconfig.read('/etc/yum/pluginconf.d/subscription-manager.conf')
+    if submanconfig.get('main','enabled') == '0':
       print_generic("subscription-manager yum plugin was disabled. Enabling...")
-      configparser.set('main', 'enabled', '1')
-      with open('/etc/yum/pluginconf.d/product-id.conf','w') as configfile:
-        configparser.write(configfile)
+      submanconfig.set('main', 'enabled', '1')
+      submanconfig.write(open('/etc/yum/pluginconf.d/subscription-manager.conf','w')) 
 
 def check_rhn_registration():
     if os.path.exists('/etc/sysconfig/rhn/systemid'):

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -495,6 +495,24 @@ def disassociate_host(host_id):
     print_running("Disassociating host id %s for host %s" % (host_id, FQDN))
     put_json(myurl)
 
+def configure_subscription_manager():
+    configparser = SafeConfigParser()
+    configparser.read('/etc/yum/pluginconf.d/product-id.conf')
+    configparser.get('main', 'enabled')
+    if configparser.get('main','enabled') == '0':
+      print_generic("Product-id yum plugin was disabled. Enabling...")
+      configparser.set('main', 'enabled', '1')
+      with open('/etc/yum/pluginconf.d/product-id.conf','w') as configfile:
+        configparser.write(configfile)
+
+    configparser = SafeConfigParser()
+    configparser.read('/etc/yum/pluginconf.d/subscription-manager.conf')
+    configparser.get('main', 'enabled')
+    if configparser.get('main','enabled') == '0':
+      print_generic("subscription-manager yum plugin was disabled. Enabling...")
+      configparser.set('main', 'enabled', '1')
+      with open('/etc/yum/pluginconf.d/product-id.conf','w') as configfile:
+        configparser.write(configfile)
 
 def check_rhn_registration():
     if os.path.exists('/etc/sysconfig/rhn/systemid'):
@@ -601,6 +619,7 @@ elif check_rhn_registration():
     API_PORT = get_api_port()
     if not options.no_foreman:
         create_host()
+    configure_subscription_manager()
     migrate_systems(options.org, options.activationkey)
 else:
     print_generic('This system is not registered to RHN. Attempting to register via subscription-manager')
@@ -608,6 +627,7 @@ else:
     API_PORT = get_api_port()
     if not options.no_foreman:
         create_host()
+    configure_subscription_manager()
     register_systems(options.org, options.activationkey, options.release)
 
 if not options.remove:


### PR DESCRIPTION
This PR ensures that the following yum plugins are enabled in subscription-manager prior running the register or migration routines. 
- the **product-id** plugin - ensures that new product certificates are placed in /etc/pki/product. Without this, systems won't get the product certs when products are installed from the various Red Hat repositories. 
- the **subscription-manager** plugin - ensures that subscription-manager works properly.
