### PR TITLE
update python to avoid gopher issues (fixes RHBZ #1360360)

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -196,7 +196,7 @@ def install_prereqs():
     print_generic("Installing subscription manager prerequisites")
     yum("remove", "subscription-manager-gnome")
     yum("install", "subscription-manager subscription-manager-migration-*")
-    yum("update", "yum openssl")
+    yum("update", "yum openssl python")
 
 
 def get_bootstrap_rpm():


### PR DESCRIPTION
From [bz1360360](https://bugzilla.redhat.com/show_bug.cgi?id=1360360):

```
Python on RHEL 6.4 and older is affected by https://bugzilla.redhat.com/show_bug.cgi?id=845802
This leads to a lot of message spam on the consoles when goferd is running.
bootstrap.py should try to upgrade python (as it does with yum, openssl etc) to avoid this issue
```
