### PR TITLE
Add --enablerepo option to support older versions of subscription-manager

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -505,11 +505,9 @@ def check_rhn_registration():
         return False
 
 def enable_repos():
-    for repo in options.enablerepos.split(','):
-      print_running("Enabling repo - %s" % repo)
-      exec_failok("/usr/sbin/subscription-manager repos --enable %s" % repo)
-
-
+    repostoenable = " ".join(['--enable=%s' % i for i in options.enablerepos.split(',')])
+    print_running("Enabling repositories - %s" % option.enablerepos)
+    exec_failok("subscription-manager repos %s" % repostoenable)
 
 def get_api_port():
     configparser = SafeConfigParser()


### PR DESCRIPTION
As part of commit https://github.com/Katello/katello-client-bootstrap/commit/1912d60eac04cba8288b06b2273d02784d28b88a,  the `enable_sat_tools` function, which explicitly enabled the Satellite Tools repositories was removed. 

This effectively meant that users are required to use a version of `subscription-manager` > 1.10 which enables / disables repository based upon the Product Content attributes of an activation key. 

Some users of particularly old versions of RHEL5 & RHEL6 do not (and cannot) have a version of subscription-manager new enough to support Product Content attributes on activation keys. This made the process of running bootstrap.py on these older systems difficult (as the required repos to install puppet or katello-agent were not enabled)

The feature adds the `--enablerepos` switch which allows a user to pass a list of repositories, comma separated (and wildcards OK) which will be enabled via `subscription-manager`

Example Usage:

```
#./bootstrap.py -l admin \
  -s server.example.com \
  -o Default \
  -g RHEL7 \
  --enablerepos *satellite*,rhel-5-server-rpms
```
