### PR TITLE
Fix legacy opts

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -100,7 +100,7 @@ if not DOMAIN and not (options.force or options.no_puppet):
 if not options.password and not options.no_foreman:
     options.password = getpass.getpass("%s's password:" % options.login)
 
-if options.legacy_login and not options.legacy_password:
+if options.legacy_purge and not options.legacy_password:
     options.legacy_password = getpass.getpass("Legacy User %s's password:" % options.legacy_login)
 
 if options.no_foreman:

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -100,6 +100,9 @@ if not DOMAIN and not (options.force or options.no_puppet):
 if not options.password and not options.no_foreman:
     options.password = getpass.getpass("%s's password:" % options.login)
 
+if options.legacy_login and not options.legacy_password:
+    options.legacy_password = getpass.getpass("Legacy User %s's password:" % options.legacy_login)
+
 if options.no_foreman:
     options.no_puppet = True
 
@@ -118,6 +121,8 @@ if options.verbose:
     print "ORG - %s" % options.org
     print "ACTIVATIONKEY - %s" % options.activationkey
     print "UPDATE - %s" % options.update
+    print "LEGACY LOGIN - %s" % options.legacy_login
+    print "LEGACY PASSWORD - %s" % options.legacy_password
 
 error_colors = {
     'HEADER': '\033[95m',


### PR DESCRIPTION
if the user passes `--legacy-purge`, we need to prompt them for `--legacy-password`if they haven't provided it via CLI parameter. 

Otherwise, the subsequent call to `rhn-migrate-classic-to-rhsm` in the `migrate_systems` function will fail. 
