### PR TITLE
Add check and graceful failure if katello-ca-consumer package is already installed. 

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -137,12 +137,8 @@ def get_bootstrap_rpm():
     """
     if options.force:
         clean_katello_agent()
-    ts = rpm.TransactionSet()
-    mi = ts.dbMatch()
-    mi.pattern('name',rpm.RPMMIRE_GLOB,'katello-ca-consumer*')
-    consumer_pkgs = sum(1 for h in mi)
-    if consumer_pkgs > 0:
-        print_generic("A katello-ca-consumer package is already installed. Assuming system is registered")
+    if os.path.exists('/etc/rhsm/ca/katello-server-ca.pem'):
+        print_generic("A katello CA certificate is already installed. Assuming system is registered")
         print_generic("To override this behavior, run the script with the --force option. Exiting.")
         sys.exit(1)
           

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -138,7 +138,7 @@ def get_bootstrap_rpm():
     if options.force:
         clean_katello_agent()
     if os.path.exists('/etc/rhsm/ca/katello-server-ca.pem'):
-        print_generic("A katello CA certificate is already installed. Assuming system is registered")
+        print_generic("A Katello CA certificate is already installed. Assuming system is registered")
         print_generic("To override this behavior, run the script with the --force option. Exiting.")
         sys.exit(1)
           

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -137,6 +137,15 @@ def get_bootstrap_rpm():
     """
     if options.force:
         clean_katello_agent()
+    ts = rpm.TransactionSet()
+    mi = ts.dbMatch()
+    mi.pattern('name',rpm.RPMMIRE_GLOB,'katello-ca-consumer*')
+    consumer_pkgs = sum(1 for h in mi)
+    if consumer_pkgs > 0:
+        print_generic("A katello-ca-consumer package is already installed. Assuming system is registered")
+        print_generic("To override this behavior, run the script with the --force option. Exiting.")
+        sys.exit(1)
+          
     print_generic("Retrieving Client CA Certificate RPMs")
     exec_failexit("rpm -Uvh http://%s/pub/katello-ca-consumer-latest.noarch.rpm" % options.foreman_fqdn)
 


### PR DESCRIPTION
Adds a more graceful message informing the user to run the script with the `--force` option in the event a `katello-ca-consumer-*` package is installed. Fixes #119 
