### PR TITLE
Update yum functions to properly escape wildcards. 

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -201,7 +201,7 @@ def check_migration_version():
 def install_prereqs():
     print_generic("Installing subscription manager prerequisites")
     yum("remove", "subscription-manager-gnome")
-    yum("install", "subscription-manager subscription-manager-migration-*")
+    yum("install", "subscription-manager 'subscription-manager-migration-*'")
     yum("update", "yum openssl python")
 
 
@@ -248,7 +248,7 @@ def unregister_system():
 
 def clean_katello_agent():
     print_generic("Removing old Katello agent and certs")
-    yum("erase", "katello-ca-consumer-* katello-agent gofer")
+    yum("erase", "'katello-ca-consumer-*' katello-agent gofer")
 
 
 def install_katello_agent():
@@ -307,7 +307,7 @@ server          = %s
 
 def remove_obsolete_packages():
     print_generic("Removing old RHN packages")
-    yum("remove", "rhn-setup rhn-client-tools yum-rhn-plugin rhnsd rhn-check rhnlib spacewalk-abrt spacewalk-oscap osad rh-*-rhui-client")
+    yum("remove", "rhn-setup rhn-client-tools yum-rhn-plugin rhnsd rhn-check rhnlib spacewalk-abrt spacewalk-oscap osad 'rh-*-rhui-client'")
 
 
 def fully_update_the_box():


### PR DESCRIPTION
In the use-case when the user has a file named `katello-ca-consumer*` in the directory which bootstrap is invoked from, the script will fail to run when using the `--force` option as the function calls `yum remove katello-ca-consumer*` which matches the file on disk, and not the one(s) in the RPM database. 

This PR updates bootstrap to ~~query the RPM database for packages named katello-ca-consumer* and pass those as explicit arguments to the `yum remove` command~~ properly quote any call to yum which has a wildcard. 

