### PR TITLE
remove Katello CA certs in clean_katello_agent

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -94,6 +94,27 @@ def exec_failexit(command):
     print_success(command)
     print ""
 
+def delete_file(filename):
+    """Helper function to delete files."""
+    try:
+        os.remove(filename)
+        print_success("Removing %s" % filename)
+    except OSError, e:
+        print_generic("Error when removing %s - %s" % (filename, e.strerror))
+        print_error("Removing %s" % filename)
+        sys.exit(1)
+
+def delete_directory(directoryname):
+    """Helper function to delete directories."""
+    try:
+        shutil.rmtree(directoryname)
+        print_success("Removing %s" % directoryname)
+    except OSError, e:
+        print_generic("Error when removing %s - %s" % (directoryname, e.strerror))
+        print_error("Removing %s" % directoryname)
+        sys.exit(1)
+
+
 
 def yum(command, pkgs=""):
     """Helper function to call a yum command on a list of packages."""
@@ -198,7 +219,7 @@ def unregister_system():
 def clean_katello_agent():
     """Remove old Katello agent (aka Gofer) and certificate RPMs."""
     print_generic("Removing old Katello agent and certs")
-    exec_failexit("rm -f /etc/rhsm/ca/katello-server-ca.pem")
+    delete_file("/etc/rhsm/ca/katello-server-ca.pem")
     yum("erase", "'katello-ca-consumer-*' katello-agent gofer")
 
 
@@ -214,7 +235,7 @@ def clean_puppet():
     """Remove old Puppet Agent and its configuration"""
     print_generic("Cleaning old Puppet Agent")
     yum("erase", "puppet")
-    exec_failexit("rm -rf /var/lib/puppet/")
+    delete_directory("/var/lib/puppet/")
 
 
 def clean_environment():
@@ -593,7 +614,7 @@ def prepare_rhel5_migration():
 
     # cleanup
     if os.path.exists('/etc/sysconfig/rhn/systemid'):
-        os.remove('/etc/sysconfig/rhn/systemid')
+        delete_file('/etc/sysconfig/rhn/systemid')
 
 if __name__ == '__main__':
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -94,6 +94,7 @@ def exec_failexit(command):
     print_success(command)
     print ""
 
+
 def delete_file(filename):
     """Helper function to delete files."""
     try:
@@ -104,6 +105,7 @@ def delete_file(filename):
         print_error("Removing %s" % filename)
         sys.exit(1)
 
+
 def delete_directory(directoryname):
     """Helper function to delete directories."""
     try:
@@ -113,7 +115,6 @@ def delete_directory(directoryname):
         print_generic("Error when removing %s - %s" % (directoryname, e.strerror))
         print_error("Removing %s" % directoryname)
         sys.exit(1)
-
 
 
 def yum(command, pkgs=""):
@@ -162,7 +163,7 @@ def get_bootstrap_rpm():
         print_generic("A Katello CA certificate is already installed. Assuming system is registered")
         print_generic("To override this behavior, run the script with the --force option. Exiting.")
         sys.exit(1)
-          
+
     print_generic("Retrieving Client CA Certificate RPMs")
     exec_failexit("rpm -Uvh http://%s/pub/katello-ca-consumer-latest.noarch.rpm" % options.foreman_fqdn)
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -198,6 +198,7 @@ def unregister_system():
 def clean_katello_agent():
     """Remove old Katello agent (aka Gofer) and certificate RPMs."""
     print_generic("Removing old Katello agent and certs")
+    exec_failexit("rm -f /etc/rhsm/ca/katello-server-ca.pem")
     yum("erase", "'katello-ca-consumer-*' katello-agent gofer")
 
 


### PR DESCRIPTION
In https://github.com/Katello/katello-client-bootstrap/pull/120, we added support for gracefully failing in the event that a system was already registered. (Done via checking for the presence of `/etc/rhsm/ca/katello-server-ca.pem`) As newer versions of the katello-ca-consumer RPM no longer deploy `/etc/rhsm/ca/katello-server-ca.pem` directly, but call `katello-rhsm-consumer`, which deploys the file, the **clean_katello_agent** function needs to delete *both* the `/etc/rhsm/ca/katello-server-ca.pem` file AND the RPM. 