### PR TITLE
import os instead of os.path

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -14,7 +14,7 @@ import sys
 import commands
 import platform
 import socket
-import os.path
+import os
 import pwd
 import glob
 import shutil


### PR DESCRIPTION
we are using both, os and os.path functions, no need to pretend we need
only os.path. (fun fact: it actually still works when you only import
os.path, but let's be explicit here)