### PR TITLE
Properly disable RHN Plugin

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -175,12 +175,13 @@ def get_bootstrap_rpm():
 
 
 def disable_rhn_plugin():
-    rhnpluginconfig = SafeConfigParser()
-    rhnpluginconfig.read('/etc/yum/pluginconf.d/rhnplugin.conf')
-    if rhnpluginconfig.get('main', 'enabled') == '1':
-        print_generic("RHN yum plugin was enabled. Disabling...")
-        rhnpluginconfig.set('main', 'enabled', '0')
-        rhnpluginconfig.write(open('/etc/yum/pluginconf.d/rhnplugin.conf', 'w'))
+    if os.path.exists('/etc/yum/pluginconf.d/rhnplugin.conf'):
+        rhnpluginconfig = SafeConfigParser()
+        rhnpluginconfig.read('/etc/yum/pluginconf.d/rhnplugin.conf')
+        if rhnpluginconfig.get('main', 'enabled') == '1':
+            print_generic("RHN yum plugin was enabled. Disabling...")
+            rhnpluginconfig.set('main', 'enabled', '0')
+            rhnpluginconfig.write(open('/etc/yum/pluginconf.d/rhnplugin.conf', 'w'))
     if os.path.exists('/etc/sysconfig/rhn/systemid'):
         os.rename('/etc/sysconfig/rhn/systemid', '/etc/sysconfig/rhn/systemid.bootstrap-bak')
 


### PR DESCRIPTION
Added `disable_rhn_plugin()` function which will disable the RHN plugin by

- moving the systemid file to systemid-bak
- disabling the RHN plugin in `/etc/yum/pluginconf.d/rhnplugin.conf`.

Updated the `migrate_systems` and `prepare_rhel5_migration ` functions to use it. 

This will ensure the RHN plugin is properly disabled at the completion of a run of bootstrap. 

This PR obsoletes #136 & #123 