### PR TITLE
Clean environment after prereqs installation

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -156,6 +156,7 @@ def install_prereqs():
     yum("remove", "subscription-manager-gnome")
     yum("install", "subscription-manager 'subscription-manager-migration-*'")
     yum("update", "yum openssl python")
+    generate_katello_facts()
 
 
 def get_bootstrap_rpm():
@@ -191,7 +192,7 @@ def migrate_systems(org_name, activationkey):
     Call `rhn-migrate-classic-to-rhsm` to migrate the machine from Satellite
     5 to 6 using the organization name/label and the given activation key, and
     configure subscription manager with the baseurl of Satellite6's pulp.
-    This allows the administrator to override the URL provided in the 
+    This allows the administrator to override the URL provided in the
     katello-ca-consumer-latest RPM, which is useful in scenarios where the
     Capsules/Servers are load-balanced or using subjectAltName certificates.
     If called with "--legacy-purge", uses "legacy-user" and "legacy-password"
@@ -267,11 +268,13 @@ def clean_puppet():
 def clean_environment():
     """
     Undefine `LD_LIBRARY_PATH` and `LD_PRELOAD` as many environments
-    have it defined non-sensibly. 
+    have it defined non-sensibly.
     """
     for key in ['LD_LIBRARY_PATH', 'LD_PRELOAD']:
         os.environ.pop(key, None)
 
+
+def generate_katello_facts():
     if FQDN.find(".") != -1 and not os.path.exists('/etc/rhsm/facts/katello.facts'):
         print_generic("Workaround for FQDN")
         katellofacts = open('/etc/rhsm/facts/katello.facts', 'w')
@@ -606,7 +609,7 @@ def prepare_rhel5_migration():
     """
     Execute specific preparations steps for RHEL 5. Older releases of RHEL 5
     did not have a version of rhn-classic-migrate-to-rhsm which supported
-    activation keys. This function allows those systems to get a proper 
+    activation keys. This function allows those systems to get a proper
     product certificate.
     """
     install_prereqs()


### PR DESCRIPTION
Since cleaning the environment relies on subscription manager
directories being available (/etc/rhsm/facts), we should run it after
the installation happens.

An alternative for https://github.com/Katello/katello-client-bootstrap/pull/144/files to fix Katello#143 and https://bugzilla.redhat.com/show_bug.cgi?id=1408972