### PR TITLE
Make sure rhsmcertd is enabled. Some users may have disabled while us…

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -156,6 +156,7 @@ def install_prereqs():
     yum("remove", "subscription-manager-gnome")
     yum("install", "subscription-manager 'subscription-manager-migration-*'")
     yum("update", "yum openssl python")
+    exec_failexit("/sbin/chkconfig rhsmcertd on")
     generate_katello_facts()
 
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -156,7 +156,6 @@ def install_prereqs():
     yum("remove", "subscription-manager-gnome")
     yum("install", "subscription-manager 'subscription-manager-migration-*'")
     yum("update", "yum openssl python")
-    exec_failexit("/sbin/chkconfig rhsmcertd on")
     generate_katello_facts()
 
 
@@ -188,6 +187,14 @@ def disable_rhn_plugin():
         os.rename('/etc/sysconfig/rhn/systemid', '/etc/sysconfig/rhn/systemid.bootstrap-bak')
 
 
+def enable_rhsmcertd():
+    """
+    Enable and restart the rhsmcertd service
+    """
+    exec_failexit("/sbin/chkconfig rhsmcertd on")
+    exec_failexit("/sbin/service rhsmcertd restart")
+
+
 def migrate_systems(org_name, activationkey):
     """
     Call `rhn-migrate-classic-to-rhsm` to migrate the machine from Satellite
@@ -214,6 +221,7 @@ def migrate_systems(org_name, activationkey):
         options.rhsmargs += " --keep"
     exec_failexit("/usr/sbin/rhn-migrate-classic-to-rhsm --org %s --activation-key '%s' %s" % (org_label, activationkey, options.rhsmargs))
     exec_failexit("subscription-manager config --rhsm.baseurl=https://%s/pulp/repos" % options.foreman_fqdn)
+    enable_rhsmcertd()
 
     # When rhn-migrate-classic-to-rhsm is called with --keep, it will leave the systemid
     # file intact, which might confuse the (not yet removed) yum-rhn-plugin.
@@ -236,6 +244,7 @@ def register_systems(org_name, activationkey, release):
     if options.force:
         options.smargs += " --force"
     exec_failexit("/usr/sbin/subscription-manager register --org '%s' --name '%s' --activationkey '%s' %s" % (org_label, FQDN, activationkey, options.smargs))
+    enable_rhsmcertd()
 
 
 def unregister_system():


### PR DESCRIPTION
…ing RHN.

Installing subscription-manager enables rhsmcertd but I ran into a case where a user had disabled rhsmcertd while using RHN and wondered why checkins were not occurring in Satellite 6.