### PR TITLE
fix evaluation of the retcode when using commands.getstatusoutput

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -73,7 +73,7 @@ def exec_failok(command):
     """Helper function to call a command with only warning if failing."""
     print_running(command)
     output = commands.getstatusoutput(command)
-    retcode = output[0]
+    retcode = output[0] >> 8
     if retcode != 0:
         print_warning(command)
     print output[1]
@@ -85,7 +85,7 @@ def exec_failexit(command):
     """Helper function to call a command with error and exit if failing."""
     print_running(command)
     output = commands.getstatusoutput(command)
-    retcode = output[0]
+    retcode = output[0] >> 8
     if retcode != 0:
         print_error(command)
         print output[1]
@@ -582,7 +582,7 @@ def configure_subscription_manager():
 def check_rhn_registration():
     """Helper function to check if host is registered to legacy RHN."""
     if os.path.exists('/etc/sysconfig/rhn/systemid'):
-        retcode = commands.getstatusoutput('rhn-channel -l')[0]
+        retcode = commands.getstatusoutput('rhn-channel -l')[0] >> 8
         return retcode == 0
     else:
         return False


### PR DESCRIPTION
commands.getstatusoutput() returns the exit code that should be
"interpreted according to the rules for the C function wait()."[1]

However, wait() does not return the exit code only, but also other
information how the process ended (like the signal). To get the exit
code, wait(3)[2] documents a macro:

 WEXITSTATUS(stat_val)
   If the value of WIFEXITED(stat_val) is non-zero, this macro
   evaluates to the low-order 8 bits of the status argument that
   the child process passed to _exit() or exit(), or the value the
   child process returned from main().

This means that we need not the whole exit status from
getstatusoutput(), but only the lower 8 bits. Get these by shifting
'result' by 8 bits to the right.

[1] https://docs.python.org/2/library/commands.html#commands.getstatusoutput
[2] https://linux.die.net/man/3/wait