### PR TITLE
Fix error handling when installing Foreman SSH key

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -352,7 +352,10 @@ def install_foreman_ssh_key():
     try:
         foreman_ssh_key = urllib2.urlopen("https://%s:9090/ssh/pubkey" % options.foreman_fqdn).read()
     except urllib2.HTTPError, e:
-        print_generic("The server was unable to fulfill the request. Error: %s" % e.code)
+        print_generic("The server was unable to fulfill the request. Error: %s - %s" % (e.code, e.reason))
+        print_generic("Please ensure the Remote Execution feature is configured properly")
+        print_warning("Installing Foreman SSH key")
+        return
     except urllib2.URLError, e:
         print_generic("Could not reach the server. Error: %s" % e.reason)
         return


### PR DESCRIPTION
From [RHBZ 1422236](https://bugzilla.redhat.com/show_bug.cgi?id=1422236):

Bootstrap fails when running with the `--rex` switch against a proxy w/o the SSH feature enabled with an error similar to:

~~~
[NOTIFICATION], [2017-02-14 17:02:48], [The server was unable to fulfill the request. Error: 404]
Traceback (most recent call last): File "./bootstrap.py", line 874, 
in install_foreman_ssh_key() File "./bootstrap.py", line 360, in 
install_foreman_ssh_key if foreman_ssh_key in 
open(foreman_ssh_authfile, 'r').read(): UnboundLocalError: 
local variable 'foreman_ssh_key' referenced before assignment
~~~

This PR
- adds a more detailed error `e.reason` as not everyone has HTTP error codes memorized
- adds a proper warning to the user with actions to take. 
- exits the `install_foreman_ssh_key` function gracefully. 

Fixes #156 