### PR TITLE
Add capsule migration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ bootstrap Script for migrating existing running systems to Foreman with the Kate
 This script can take a system that is registered to Spacewalk, Satellite 5, Red Hat
 Network Classic and get it registered to Foreman & Katello.
 
+Optionally, you can also move systems from one Satellite 6 system or Capsule to
+another by using the --new-capsule option.
+
 # What does the Script do?
 
 * Identify which systems management platform is the system registered to (Classic/Sat5 or None)  then perform the following
@@ -28,6 +31,17 @@ Network Classic and get it registered to Foreman & Katello.
 * Running subscription-manager (with the user provided activation key) to register the system.
 * Configuring the system with a proper Puppet configuration pointing at Foreman
 * Removing/disabling old RHN Classic packages/daemons (rhnsd, osad, etc)
+
+## System already registered to a Satellite 6 server / Capsule (--new-capsule)
+* Clean the existing Katello agent installation
+* Install the Katello consumer RPM for the target Satellite 6 server / Capsule
+* Install the Katello agent software again, using the configuration for the
+  target Satellite 6 / Capsule server
+* Make API calls to update the Puppet master, Puppet CA, content source and
+  OpenSCAP proxy IDs
+* Re-enable rhsmcertd
+* Update the Puppet configuration for the system to point to the 
+* Restart Puppet and call for the user to go sign the CSR
 
 # Assumptions
 
@@ -169,6 +183,18 @@ By default, bootstrap.py does not delete the system's profile from the legacy pl
 ### Migrating a system from one Foreman + Katello installation to another.
 
 There are times where it is necessary to migrate clients from one Foreman + Katello installation to another. For instance, in lieu of upgrading an older Foreman + Katello installation, you choose to build a new installation in parallel. bootstrap.py can then be used to migrate clients from one Foreman + Katello installation to another. Simply provide the `--force` option, and bootstrap.py will remove the previous `katello-ca-consumer-*` package (from the old system), and will install the `katello-ca-consumer-*` package (from the new system), and continue registration as usual.
+
+### Migrating a system from one Satellite 6 / Capsule to another in the same infrastructure
+
+In order to manually balance the load over multiple Capsule servers, you might
+want to move some existing systems to newly deployed Capsules. You can easily
+do this by running the bootstrap.py script like so:
+
+
+~~~
+# ./bootstrap.py --new-capsule \
+  --server new.capsule.server
+~~~
 
 ### Enabling additional repositories at registration time.
 
@@ -418,6 +444,8 @@ Options:
   --ip=IP               IPv4 address of the primary interface in Foreman
                         (defaults to the address used to make request to
                         Foreman)
+  --new-capsule         Migrate the system to a new Capsule server, pass the
+                        name of the new Capsule with the --server option
 ~~~
 
 # For developers:

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -160,13 +160,13 @@ def install_prereqs():
         yum("update", "yum openssl python")
 
 
-def get_bootstrap_rpm():
+def get_bootstrap_rpm(clean=False):
     """
     Retrieve Client CA Certificate RPMs from the Satellite 6 server.
     Uses --insecure options to curl(1) if instructed to download via HTTPS
     If called with --force, calls clean_katello_agent().
     """
-    if options.force:
+    if options.force or clean == True:
         clean_katello_agent()
     if os.path.exists('/etc/rhsm/ca/katello-server-ca.pem'):
         print_generic("A Katello CA certificate is already installed. Assuming system is registered")
@@ -936,8 +936,7 @@ if __name__ == '__main__':
         # > Puppet, OpenSCAP and update Puppet configuration
         # > MANUAL SIGNING OF CSR OR MANUALLY CREATING AUTO-SIGN RULE STILL REQUIRED!
         # > API doesn't have a public provision for creating auto-sign entries yet!
-        options.force = True  # Need to set this to make get_bootstrap_rpm() to perform the right way
-        get_bootstrap_rpm()
+        get_bootstrap_rpm(clean=True)
         install_katello_agent()
         API_PORT = get_api_port()
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -936,9 +936,8 @@ if __name__ == '__main__':
         # > Puppet, OpenSCAP and update Puppet configuration
         # > MANUAL SIGNING OF CSR OR MANUALLY CREATING AUTO-SIGN RULE STILL REQUIRED!
         # > API doesn't have a public provision for creating auto-sign entries yet!
-        print_running("Removing katello-*, gofer and installing new Katello certificate")
-        clean_katello_agent()
-        exec_failexit("rpm -Uvh http://%s/pub/katello-ca-consumer-latest.noarch.rpm" % options.foreman_fqdn)
+        options.force = True  # Need to set this to make get_bootstrap_rpm() to perform the right way
+        get_bootstrap_rpm()
         install_katello_agent()
         API_PORT = get_api_port()
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -166,7 +166,7 @@ def get_bootstrap_rpm(clean=False):
     Uses --insecure options to curl(1) if instructed to download via HTTPS
     If called with --force, calls clean_katello_agent().
     """
-    if options.force or clean == True:
+    if clean == True:
         clean_katello_agent()
     if os.path.exists('/etc/rhsm/ca/katello-server-ca.pem'):
         print_generic("A Katello CA certificate is already installed. Assuming system is registered")
@@ -919,7 +919,7 @@ if __name__ == '__main__':
         print_generic('This system is registered to RHN. Attempting to migrate via rhn-classic-migrate-to-rhsm')
         install_prereqs()
         check_migration_version()
-        get_bootstrap_rpm()
+        get_bootstrap_rpm(clean=options.force)
         generate_katello_facts()
         API_PORT = get_api_port()
         if 'foreman' not in options.skip:
@@ -971,7 +971,7 @@ if __name__ == '__main__':
         # > ELSE get CA RPM, optionally create host,
         # >      register via subscription-manager
         print_generic('This system is not registered to RHN. Attempting to register via subscription-manager')
-        get_bootstrap_rpm()
+        get_bootstrap_rpm(clean=options.force)
         generate_katello_facts()
         API_PORT = get_api_port()
         if 'foreman' not in options.skip:

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -894,8 +894,8 @@ if __name__ == '__main__':
     # > Clean the environment from LD_... variables
     clean_environment()
 
-    # > IF RHEL 5 and not removing, prepare the migration.
-    if not options.remove and int(RELEASE[0]) == 5:
+    # > IF RHEL 5, not removing, and not moving to new capsule prepare the migration.
+    if not options.remove and int(RELEASE[0]) == 5 and not options.new_capsule:
         prepare_rhel5_migration()
 
     if options.remove:

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -459,9 +459,9 @@ def delete_json(url):
     return call_api(url, method='DELETE')
 
 
-def put_json(url):
+def put_json(url, jdata=None):
     """Use `call_api` to place a "PUT" REST API call."""
-    return call_api(url, method='PUT')
+    return call_api(url, data=jdata, method='PUT')
 
 
 def return_matching_foreman_key(api_name, search_key, return_key, null_result_ok=False):

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -955,11 +955,11 @@ if __name__ == '__main__':
         print_running("Stopping the Puppet agent for configuration update")
         exec_failok("/sbin/service puppet stop")   # failok because people might be running Puppet from cron
 
+        # Not using clean_puppet() and install_puppet_agent() here, because
+        # that would nuke custom /etc/puppet/puppet.conf files, which might
+        # yield undesirable results.
         print_running("Updating Puppet configuration")
-        pupcfg = SafeConfigParser()
-        pupcfg.read("/etc/puppet/puppet.conf")
-        pupcfg.set("agent", "server", options.foreman_fqdn)
-        pupcfg.write("/etc/puppet/puppet.conf")
+        exec_failexit("sed -i 's/^[[:space:]]*server.*/   server     = %s/' /etc/puppet/puppet.conf" % options.foreman_fqdn)
         delete_directory("/var/lib/puppet/ssl")
         delete_file("/var/lib/puppet/client_data/catalog/%s.json" % FQDN)
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -164,7 +164,8 @@ def get_bootstrap_rpm(clean=False):
     """
     Retrieve Client CA Certificate RPMs from the Satellite 6 server.
     Uses --insecure options to curl(1) if instructed to download via HTTPS
-    If called with --force, calls clean_katello_agent().
+    This function is usually called with clean=options.force, which ensures
+    clean_katello_agent() is called is --force is specified.
     """
     if clean:
         clean_katello_agent()

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -463,10 +463,12 @@ def put_json(url, jdata=None):
     """Use `call_api` to place a "PUT" REST API call."""
     return call_api(url, data=jdata, method='PUT')
 
+
 def update_host_capsule_mapping(server, port, attribute, capsule_id, host_id):
     url = "https://" + server + ":" + str(port) + "/api/v2/hosts/" + str(host_id)
     jdata = json.loads('{"host": {"%s": "%s"}}' % (attribute, capsule_id))
     return put_json(url, jdata)
+
 
 def return_matching_foreman_key(api_name, search_key, return_key, null_result_ok=False):
     """
@@ -890,7 +892,6 @@ if __name__ == '__main__':
             except ImportError:
                 print_error("Could not install python-simplejson")
 
-
     # > Clean the environment from LD_... variables
     clean_environment()
 
@@ -930,7 +931,7 @@ if __name__ == '__main__':
             enable_repos()
     elif options.new_capsule and options.foreman_fqdn:
         # > ELIF new_capsule and foreman_fqdn set, will migrate to other capsule
-        # 
+        #
         # > will replace CA certificate, reinstall katello-agent, gofer
         # > update system definition to point to new capsule for content,
         # > Puppet, OpenSCAP and update Puppet configuration
@@ -955,7 +956,7 @@ if __name__ == '__main__':
         exec_failexit("/sbin/service goferd restart")
 
         print_running("Stopping the Puppet agent for configuration update")
-        exec_failok("/sbin/service puppet stop") # failok because people might be running Puppet from cron
+        exec_failok("/sbin/service puppet stop")   # failok because people might be running Puppet from cron
 
         print_running("Updating Puppet configuration")
         exec_failexit("/usr/bin/puppet config set --section agent server %s" % options.foreman_fqdn)
@@ -999,4 +1000,3 @@ if __name__ == '__main__':
 
         if options.remote_exec:
             install_foreman_ssh_key()
-

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -206,6 +206,7 @@ def enable_rhsmcertd():
     """
     Enable and restart the rhsmcertd service
     """
+    print_running("Enabling and restarting rhsmcertd...")
     exec_failexit("/sbin/chkconfig rhsmcertd on")
     exec_failexit("/sbin/service rhsmcertd restart")
 
@@ -948,7 +949,6 @@ if __name__ == '__main__':
         update_host_capsule_mapping("content_source_id", capsule_id, host_id)
         update_host_capsule_mapping("openscap_proxy_id", capsule_id, host_id)
 
-        print_running("Restarting rhsmcertd")
         enable_rhsmcertd()
 
         print_running("Stopping the Puppet agent for configuration update")

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -889,6 +889,7 @@ if __name__ == '__main__':
                 import simplejson as json
             except ImportError:
                 print_error("Could not install python-simplejson")
+                sys.exit(1)
 
     # > Clean the environment from LD_... variables
     clean_environment()

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -944,15 +944,13 @@ if __name__ == '__main__':
         print_running("Calling Foreman API to update content source, puppet master, puppet ca and openscap proxy records for %s" % FQDN)
         capsule_id = return_matching_katello_key('capsules', 'name="%s"' % options.foreman_fqdn, 'id', False)
         host_id = return_matching_foreman_key('hosts', 'name="%s"' % FQDN, 'id', False)
-
         update_host_capsule_mapping(options.foreman_fqdn, API_PORT, "puppet_proxy_id", capsule_id, host_id)
         update_host_capsule_mapping(options.foreman_fqdn, API_PORT, "puppet_ca_proxy_id", capsule_id, host_id)
         update_host_capsule_mapping(options.foreman_fqdn, API_PORT, "content_source_id", capsule_id, host_id)
         update_host_capsule_mapping(options.foreman_fqdn, API_PORT, "openscap_proxy_id", capsule_id, host_id)
 
-        print_running("Restarting goferd and rhsmcertd")
-        exec_failexit("/sbin/service rhsmcertd restart")
-        exec_failexit("/sbin/service goferd restart")
+        print_running("Restarting rhsmcertd")
+        enable_rhsmcertd()
 
         print_running("Stopping the Puppet agent for configuration update")
         exec_failok("/sbin/service puppet stop")   # failok because people might be running Puppet from cron

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -960,6 +960,7 @@ if __name__ == '__main__':
         # yield undesirable results.
         print_running("Updating Puppet configuration")
         exec_failexit("sed -i 's/^[[:space:]]*server.*/   server     = %s/' /etc/puppet/puppet.conf" % options.foreman_fqdn)
+        exec_failok("sed -i 's/^[[:space:]]*ca_server.*/   server     = %s/' /etc/puppet/puppet.conf" % options.foreman_fqdn)  # For RHEL5 stock puppet.conf
         delete_directory("/var/lib/puppet/ssl")
         delete_file("/var/lib/puppet/client_data/catalog/%s.json" % FQDN)
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -166,7 +166,7 @@ def get_bootstrap_rpm(clean=False):
     Uses --insecure options to curl(1) if instructed to download via HTTPS
     If called with --force, calls clean_katello_agent().
     """
-    if clean == True:
+    if clean:
         clean_katello_agent()
     if os.path.exists('/etc/rhsm/ca/katello-server-ca.pem'):
         print_generic("A Katello CA certificate is already installed. Assuming system is registered")

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -464,8 +464,8 @@ def put_json(url, jdata=None):
     return call_api(url, data=jdata, method='PUT')
 
 
-def update_host_capsule_mapping(server, port, attribute, capsule_id, host_id):
-    url = "https://" + server + ":" + str(port) + "/api/v2/hosts/" + str(host_id)
+def update_host_capsule_mapping(attribute, capsule_id, host_id):
+    url = "https://" + options.foreman_fqdn + ":" + str(API_PORT) + "/api/v2/hosts/" + str(host_id)
     jdata = json.loads('{"host": {"%s": "%s"}}' % (attribute, capsule_id))
     return put_json(url, jdata)
 
@@ -944,10 +944,10 @@ if __name__ == '__main__':
         print_running("Calling Foreman API to update content source, puppet master, puppet ca and openscap proxy records for %s" % FQDN)
         capsule_id = return_matching_katello_key('capsules', 'name="%s"' % options.foreman_fqdn, 'id', False)
         host_id = return_matching_foreman_key('hosts', 'name="%s"' % FQDN, 'id', False)
-        update_host_capsule_mapping(options.foreman_fqdn, API_PORT, "puppet_proxy_id", capsule_id, host_id)
-        update_host_capsule_mapping(options.foreman_fqdn, API_PORT, "puppet_ca_proxy_id", capsule_id, host_id)
-        update_host_capsule_mapping(options.foreman_fqdn, API_PORT, "content_source_id", capsule_id, host_id)
-        update_host_capsule_mapping(options.foreman_fqdn, API_PORT, "openscap_proxy_id", capsule_id, host_id)
+        update_host_capsule_mapping("puppet_proxy_id", capsule_id, host_id)
+        update_host_capsule_mapping("puppet_ca_proxy_id", capsule_id, host_id)
+        update_host_capsule_mapping("content_source_id", capsule_id, host_id)
+        update_host_capsule_mapping("openscap_proxy_id", capsule_id, host_id)
 
         print_running("Restarting rhsmcertd")
         enable_rhsmcertd()

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -943,7 +943,7 @@ if __name__ == '__main__':
         API_PORT = get_api_port()
 
         print_running("Calling Foreman API to update content source, puppet master, puppet ca and openscap proxy records for %s" % FQDN)
-        capsule_id = return_matching_katello_key('capsules', 'name="%s"' % options.foreman_fqdn, 'id', False)
+        capsule_id = return_matching_foreman_key('smart_proxies', 'name="%s"' % options.foreman_fqdn, 'id', False)
         host_id = return_matching_foreman_key('hosts', 'name="%s"' % FQDN, 'id', False)
         update_host_capsule_mapping("puppet_proxy_id", capsule_id, host_id)
         update_host_capsule_mapping("puppet_ca_proxy_id", capsule_id, host_id)

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -956,7 +956,10 @@ if __name__ == '__main__':
         exec_failok("/sbin/service puppet stop")   # failok because people might be running Puppet from cron
 
         print_running("Updating Puppet configuration")
-        exec_failexit("/usr/bin/puppet config set --section agent server %s" % options.foreman_fqdn)
+        pupcfg = SafeConfigParser()
+        pupcfg.read("/etc/puppet/puppet.conf")
+        pupcfg.set("agent", "server", options.foreman_fqdn)
+        pupcfg.write("/etc/puppet/puppet.conf")
         delete_directory("/var/lib/puppet/ssl")
         delete_file("/var/lib/puppet/client_data/catalog/%s.json" % FQDN)
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -772,8 +772,6 @@ if __name__ == '__main__':
         options.skip.append('puppet')
     if not options.removepkgs:
         options.skip.append('remove-obsolete-packages')
-    if options.new_capsule:
-        API_PORT = "8443"
 
     # > Validate that the options make sense or exit with a message.
     # the logic is as follows:
@@ -941,6 +939,7 @@ if __name__ == '__main__':
         clean_katello_agent()
         exec_failexit("rpm -Uvh http://%s/pub/katello-ca-consumer-latest.noarch.rpm" % options.foreman_fqdn)
         install_katello_agent()
+        API_PORT = get_api_port()
 
         print_running("Calling Foreman API to update content source, puppet master, puppet ca and openscap proxy records for %s" % FQDN)
         capsule_id = return_matching_katello_key('capsules', 'name="%s"' % options.foreman_fqdn, 'id', False)


### PR DESCRIPTION
I added a --new-capsule option, as discussed on Rocket.Chat. 

It took some going back and forth and trying out various existing methods. I used some, like clean_katello_agent(), and ignored some others (clean_puppet()) for simplicity's sake.

I have tested with a RHEL7 machine, but I see no reason this shouldn't work on a RHEL6 client. The only piece of code that is not mine that I'm potentially hitting is the put_json() function, which seems to be called in disassociate_host(). Haven't tested, but I don't think it breaks anything.

