### PR TITLE
Add AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,21 @@
+AUTHORS
+======= 
+
+Daniel Lobato Garcia <me@daniellobato.me>
+Daniele Palumbo <daniele@retaggio.net>
+David Kaylor <dkaylor@redhat.com>
+Eric D Helms <ericdhelms@gmail.com>
+Eric Lavarde <elavarde@redhat.com>
+Evgeni Golov <evgeni@golov.de>
+François Cami <fcami@fedoraproject.org>
+Johan Bergström <bergsjoh@gmail.com>
+Johan Swensson <jswensso@redhat.com>
+karmab <karimboumedhel@gmail.com>
+Lukas Zapletal <lzap+git@redhat.com>
+Marcelo Moreira de Mello <mmello@redhat.com>
+Mike McCune <mmccune@gmail.com>
+Rich Jerrido <rjerrido@outsidaz.org>
+Roman Plevka <rplevka@redhat.com>
+Simon Piette <simon.piette@savoirfairelinux.com>
+Vagner Farias <vfarias@gmail.com>
+Yannick Charton <tontonitch-pro@yahoo.fr>


### PR DESCRIPTION
Add AUTHORs file for contributors. Gathered via `git log --format='%aN <%aE>' | sort -f | uniq `. 

If the user had > 1 email, I'd picked the one that seemed most appropriate. 