### PR TITLE
Add --deps-repository-* options to allow user to specify repo with subscription-manager + dependencies

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,21 @@
+AUTHORS
+======= 
+
+Daniel Lobato Garcia <me@daniellobato.me>
+Daniele Palumbo <daniele@retaggio.net>
+David Kaylor <dkaylor@redhat.com>
+Eric D Helms <ericdhelms@gmail.com>
+Eric Lavarde <elavarde@redhat.com>
+Evgeni Golov <evgeni@golov.de>
+François Cami <fcami@fedoraproject.org>
+Johan Bergström <bergsjoh@gmail.com>
+Johan Swensson <jswensso@redhat.com>
+karmab <karimboumedhel@gmail.com>
+Lukas Zapletal <lzap+git@redhat.com>
+Marcelo Moreira de Mello <mmello@redhat.com>
+Mike McCune <mmccune@gmail.com>
+Rich Jerrido <rjerrido@outsidaz.org>
+Roman Plevka <rplevka@redhat.com>
+Simon Piette <simon.piette@savoirfairelinux.com>
+Vagner Farias <vfarias@gmail.com>
+Yannick Charton <tontonitch-pro@yahoo.fr>

--- a/README.md
+++ b/README.md
@@ -338,6 +338,26 @@ On machines with multiple interfaces or multiple addresses on one interface, it 
     --ip 192.0.2.23
 ~~~
 
+### Providing a repository with the subscription-manager packages
+
+For clients who do not have subscription-manager installed (which is a prerequisite of `bootstrap.py`), the `deps-repository-url` option can be used to specify a yum repository which contains the `subscription-manager` RPMs
+
+On your Foreman instance, kickstart repositories are available via HTTP, and are ideal to be used in this scenario. However, any yum repository with the required packages would work.  
+
+~~~
+./bootstrap.py -l admin \
+    -s foreman.example.com \
+    -o "Red Hat" \
+    -L RDU \
+    -g "RHEL7/Crash" \
+    -a ak-Reg_To_Crash \
+    --download-method https \
+    --deps-repository-url "http://server.example.com/pulp/repos/Example/Library/content/dist/rhel/server/7/7.2/x86_64/kickstart/"
+~~~
+
+Also, the `--deps-repository-gpg-key` option (defaults to `file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release`) is available if the GPG key for the repository differs from `/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release`
+
+
 # Help / Available options:
 
 ~~~


### PR DESCRIPTION
Fixes #172

Major changes

- Added two new options
~~~
--deps-repository-url" - URL to a repository that contains 
       the subscription-manager RPMs
--deps-repository-gpg-key" - GPG Key to the repository that contains 
      the subscription-manager RPMs. 
      (defaults to file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release")
~~~

- Call `install_prereqs()` even in non-migration use-cases
- update `install_prereqs()` to check if `subscription-manager` is installed or available. If not installed, attempt to install the package if it is available. Otherwise, exit. (and inform user of the switches above). 

Example usage

~~~
./bootstrap.py -s server.example.com   \
  -o Example \
  -a ak_Reg_To_Dev_EL7 \
  -g 'RHEL7/BS-Dev'   \
  -L Philadelphia  \
  --deps-repository-url "http://server.example.com/pulp/repos/Example/Library/content/dist/rhel/server/7/7.2/x86_64/kickstart/"
~~~