### PR TITLE
fall back to port 443 if for some reason it is not in rhsm.conf

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -636,7 +636,10 @@ def get_api_port():
     """Helper function to get the server port from Subscription Manager."""
     configparser = SafeConfigParser()
     configparser.read('/etc/rhsm/rhsm.conf')
-    return configparser.get('server', 'port')
+    try:
+        return configparser.get('server', 'port')
+    except:
+        return "443"
 
 
 print "Foreman Bootstrap Script"


### PR DESCRIPTION
this prevents errors like:

    ConfigParser.NoOptionError: No option 'port' in section: 'server'

This can happen when you install katello-ca-consumer on a machine with
old subscription-manager, which triggers the "alternative" configuration
using sed, the old rhsm.conf did not have a port entry for whatever
reason and sed thus will not add the missing line.

See https://github.com/Katello/puppet-certs/blob/master/templates/rhsm-katello-reconfigure.erb#L63