### PR TITLE
Fixes filter_string function

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -51,7 +51,11 @@ error_colors = {
 
 def filter_string(string):
     """Helper function to filter out passwords from strings"""
-    return string.replace(str(options.password), '******').replace(str(options.legacy_password), '******')
+    if options.password:
+        string = string.replace(options.password, '******')
+    if options.legacy_password:
+        string = string.replace(options.legacy_password, '******')
+    return string
 
 
 def print_error(msg):

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -51,7 +51,7 @@ error_colors = {
 
 def filter_string(string):
     """Helper function to filter out passwords from strings"""
-    return string.replace(options.password, '******').replace(options.legacy_password, '******')
+    return string.replace(str(options.password), '******').replace(str(options.legacy_password), '******')
 
 
 def print_error(msg):


### PR DESCRIPTION
./bootstrap.py -s sat6 -l admin -p pass -a ak --skip=foreman -o org --force

Foreman Bootstrap Script
This script is designed to register new systems or to migrate an existing system to a Foreman server with Katello
[NOTIFICATION], [2017-07-05 22:42:09], [This system is not registered to RHN. Attempting to register via subscription-manager] 
[NOTIFICATION], [2017-07-05 22:42:09], [Checking subscription manager prerequisites] 
Loaded plugins: langpacks, product-id
Traceback (most recent call last):
  File "./bootstrap.py", line 1014, in <module>
    install_prereqs()
  File "./bootstrap.py", line 200, in install_prereqs
    call_yum("remove", "subscription-manager-gnome")
  File "./bootstrap.py", line 146, in call_yum
    exec_failexit("/usr/bin/yum -y %s %s" % (command, params))
  File "./bootstrap.py", line 98, in exec_failexit
    filtered_command = filter_string(command)
  File "./bootstrap.py", line 54, in filter_string
    return string.replace(options.password, '******').replace(options.legacy_password, '******')
TypeError: expected a character buffer object