### PR TITLE
Add condition to run and enable goferd,puppet,rhsmcertd via systemctl

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -775,7 +775,7 @@ def enable_service(service, failonerror=True):
     if failonerror:
         if os.path.exists("/run/systemd"):
             exec_failexit("/usr/bin/systemctl enable %s" % (service))
-       else:
+        else:
             exec_failexit("/sbin/chkconfig %s on" % (service))
     else:
         if os.path.exists("/run/systemd"):

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -264,8 +264,13 @@ def enable_rhsmcertd():
     """
     Enable and restart the rhsmcertd service
     """
-    exec_failexit("/sbin/chkconfig rhsmcertd on")
-    exec_failexit("/sbin/service rhsmcertd restart")
+
+    if int(RELEASE[0]) >= 7:
+        exec_failexit("/usr/bin/systemctl enable rhsmcertd")
+        exec_failexit("/usr/bin/systemctl restart rhsmcertd")
+    else:
+        exec_failexit("/sbin/chkconfig rhsmcertd on")
+        exec_failexit("/sbin/service rhsmcertd restart")
 
 
 def migrate_systems(org_name, activationkey):
@@ -337,8 +342,13 @@ def install_katello_agent():
     """Install Katello agent (aka Gofer) and activate /start it."""
     print_generic("Installing the Katello agent")
     call_yum("install", "katello-agent")
-    exec_failexit("/sbin/chkconfig goferd on")
-    exec_failexit("/sbin/service goferd restart")
+
+    if int(RELEASE[0]) >= 7:
+       exec_failexit("/usr/bin/systemctl enable goferd")
+       exec_failexit("/usr/bin/systemctl restart goferd")
+    else:
+       exec_failexit("/sbin/chkconfig goferd on")
+       exec_failexit("/sbin/service goferd restart")
 
 
 def clean_puppet():
@@ -374,7 +384,12 @@ def install_puppet_agent():
     puppet_env = return_puppetenv_for_hg(return_matching_foreman_key('hostgroups', 'title="%s"' % options.hostgroup, 'id', False))
     print_generic("Installing the Puppet Agent")
     call_yum("install", "puppet")
-    exec_failexit("/sbin/chkconfig puppet on")
+
+    if int(RELEASE[0]) >= 7:
+        exec_failexit("/usr/bin/systemctl enable puppet")
+    else:
+        exec_failexit("/sbin/chkconfig puppet on")
+
     puppet_conf = open('/etc/puppet/puppet.conf', 'wb')
     puppet_conf.write("""
 [main]
@@ -401,9 +416,12 @@ server          = %s
     print_generic("if auto-signing is disabled")
     exec_failexit("/usr/bin/puppet agent --test --noop --tags no_such_tag --waitforcert 10")
     if 'puppet-enable' not in options.skip:
-        exec_failexit("/sbin/chkconfig puppet on")
-        exec_failexit("/sbin/service puppet restart")
-
+        if int(RELEASE[0]) >= 7:
+            exec_failexit("/usr/bin/systemctl enable puppet")
+            exec_failexit("/sbin/systemctl puppet restart")
+        else:
+            exec_failexit("/sbin/chkconfig puppet on")
+            exec_failexit("/sbin/service puppet restart")
 
 def remove_obsolete_packages():
     """Remove old RHN packages"""

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -344,11 +344,11 @@ def install_katello_agent():
     call_yum("install", "katello-agent")
 
     if int(RELEASE[0]) >= 7:
-       exec_failexit("/usr/bin/systemctl enable goferd")
-       exec_failexit("/usr/bin/systemctl restart goferd")
+        exec_failexit("/usr/bin/systemctl enable goferd")
+        exec_failexit("/usr/bin/systemctl restart goferd")
     else:
-       exec_failexit("/sbin/chkconfig goferd on")
-       exec_failexit("/sbin/service goferd restart")
+        exec_failexit("/sbin/chkconfig goferd on")
+        exec_failexit("/sbin/service goferd restart")
 
 
 def clean_puppet():
@@ -422,6 +422,7 @@ server          = %s
         else:
             exec_failexit("/sbin/chkconfig puppet on")
             exec_failexit("/sbin/service puppet restart")
+
 
 def remove_obsolete_packages():
     """Remove old RHN packages"""

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -265,7 +265,7 @@ def enable_rhsmcertd():
     Enable and restart the rhsmcertd service
     """
     enable_service("rhsmcertd")
-    start_service("rhsmcertd")
+    exec_service("rhsmcertd", "restart")
 
 
 def migrate_systems(org_name, activationkey):
@@ -338,7 +338,7 @@ def install_katello_agent():
     print_generic("Installing the Katello agent")
     call_yum("install", "katello-agent")
     enable_service("goferd")
-    start_service("restart", "goferd")
+    exec_service("goferd", "restart")
 
 
 def clean_puppet():
@@ -403,7 +403,7 @@ server          = %s
     exec_failexit("/usr/bin/puppet agent --test --noop --tags no_such_tag --waitforcert 10")
     if 'puppet-enable' not in options.skip:
         enable_service("puppet")
-        start_service("restart", "puppet")
+        exec_service("puppet", "restart")
 
 
 def remove_obsolete_packages():
@@ -784,9 +784,10 @@ def enable_service(service, failonerror=True):
             exec_failok("/sbin/chkconfig %s on" % (service))
 
 
-def start_service(service, command="start", failonerror=True):
+def exec_service(service, command, failonerror=True):
     """
     Helper function to call a service command using proper init system.
+    Available command values = start, stop, restart
     pass failonerror = False to make init system's commands non-fatal
     """
     if failonerror:

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -774,14 +774,14 @@ def enable_service(service, failonerror=True):
     """
     if failonerror:
         if os.path.exists("/run/systemd"):
-	    exec_failexit("/usr/bin/systemctl enable %s" % (service))
-        else:
-	    exec_failexit("/sbin/chkconfig %s on" % (service))
+            exec_failexit("/usr/bin/systemctl enable %s" % (service))
+       else:
+            exec_failexit("/sbin/chkconfig %s on" % (service))
     else:
         if os.path.exists("/run/systemd"):
-	    exec_failok("/usr/bin/systemctl enable %s" % (service))
+            exec_failok("/usr/bin/systemctl enable %s" % (service))
         else:
-	    exec_failok("/sbin/chkconfig %s on" % (service))
+            exec_failok("/sbin/chkconfig %s on" % (service))
 
 
 def start_service(service, command="start", failonerror=True):
@@ -791,14 +791,14 @@ def start_service(service, command="start", failonerror=True):
     """
     if failonerror:
         if os.path.exists("/run/systemd"):
-	    exec_failexit("/usr/bin/systemctl %s %s" % (command, service))
+            exec_failexit("/usr/bin/systemctl %s %s" % (command, service))
         else:
-	    exec_failexit("/sbin/service %s %s %" (service, command))
+            exec_failexit("/sbin/service %s %s %" (service, command))
     else:
         if os.path.exists("/run/systemd"):
-	    exec_failok("/usr/bin/systemctl %s %s" % (command, service))
+            exec_failok("/usr/bin/systemctl %s %s" % (command, service))
         else:
-	    exec_failok("/sbin/service %s %s" % (service, command))
+            exec_failok("/sbin/service %s %s" % (service, command))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add condition to execute and enable: goferd, puppet and rhsmcertd via systemctl for RHEL >= 7 instead of chkconfig and service. This fixes some errors running bootstrap.py on RHEL7 using third party automation systems (issue #142)


