### PR TITLE
Adding --release to subscription-manager

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -316,6 +316,8 @@ def register_systems(org_name, activationkey, release):
     options.smargs += " --serverurl=https://%s:%s/rhsm --baseurl=https://%s/pulp/repos" % (options.foreman_fqdn, API_PORT, options.foreman_fqdn)
     if options.force:
         options.smargs += " --force"
+    if release:
+        options.smargs += " --release %s" % release
     exec_failexit("/usr/sbin/subscription-manager register --org '%s' --name '%s' --activationkey '%s' %s" % (org_label, FQDN, activationkey, options.smargs))
     enable_rhsmcertd()
 


### PR DESCRIPTION
Adding --release <release> at registration time is needed when using a different release from default (ie 7Server vs 7.3). Otherwise, subscription is done properly (but using 7Server) and then katello (or other RPMs) installation fail because the CV/repo contains only 7.3 repos. 

Also, note that register_systems function seems to be prepared for this as release is one of the arguments received but never used in the function. This commit just finishes the work.