### PR TITLE
clean up local subscription data when force-registering

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -316,6 +316,8 @@ def register_systems(org_name, activationkey, release):
     options.smargs += " --serverurl=https://%s:%s/rhsm --baseurl=https://%s/pulp/repos" % (options.foreman_fqdn, API_PORT, options.foreman_fqdn)
     if options.force:
         options.smargs += " --force"
+        exec_failok("subscription-manager unregister")
+        exec_failok("subscription-manager clean")
     exec_failexit("/usr/sbin/subscription-manager register --org '%s' --name '%s' --activationkey '%s' %s" % (org_label, FQDN, activationkey, options.smargs))
     enable_rhsmcertd()
 


### PR DESCRIPTION
subscription-manager in some versions does not like if there are local
certificates left that are signed by a previous CA. see RHBZ#1484830 for
details.

to workaround this behaviour, let's call sub-man unregister and sub-man
clean to wipe out all local information (but also try to unregister, if
that is possible).

RHBZ#1484830: https://bugzilla.redhat.com/show_bug.cgi?id=1484830