### PR TITLE
prepare 1.4.1 release

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -28,7 +28,7 @@ from urllib import urlencode
 from ConfigParser import SafeConfigParser
 
 
-VERSION = '1.4.0'
+VERSION = '1.4.1'
 
 
 def get_architecture():


### PR DESCRIPTION
changelog:

* clean up local subscription data when force-registering (#206)
* hide passwords in output when running commands (#185)
* add deprecation warnings for `--skip-foreman` and `--skip-puppet` (#192)
* default to using https everywhere (#201)
* use `systemctl` directly instead of going via `service`/`chkconfig` (#142)
* properly pass `--release` to `subscription-manager` (#73)
