### PR TITLE
Fixes #21132 - Incorrect sequence

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -331,8 +331,8 @@ def unregister_system():
 def clean_katello_agent():
     """Remove old Katello agent (aka Gofer) and certificate RPMs."""
     print_generic("Removing old Katello agent and certs")
-    delete_file("/etc/rhsm/ca/katello-server-ca.pem")
     call_yum("erase", "'katello-ca-consumer-*' katello-agent gofer")
+    delete_file("/etc/rhsm/ca/katello-server-ca.pem")
 
 
 def install_katello_agent():


### PR DESCRIPTION
PR to fix the incorrect sequence of removing CA cert and running yum command while using --force option with bootstrap.py 

Earlier it was failing with below error: 

[SUCCESS], [2017-09-26 09:34:21], [Removing /etc/rhsm/ca/katello-server-ca.pem], completed successfully.      
[RUNNING], [2017-09-26 09:34:21], [/usr/bin/yum -y erase 'katello-ca-consumer-*' katello-agent gofer]         
Loaded plugins: product-id, search-disabled-repos, security, subscription-
              : manager
Setting up Remove Process
No Match for argument: katello-agent
Repo rhel-6-server-rpms forced skip_if_unavailable=True due to: /etc/rhsm/ca/katello-server-ca.pem
https://satellite.example.com/pulp/repos/example/Library/cv-rhel6-core/content/dist/rhel/server/6/6Server/x86_ 14] PYCURL ERROR 77 - "Problem with the SSL CA cert (path? access rights?)"
Trying other mirror.