### PR TITLE
prepare 1.4.2 release

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -28,7 +28,7 @@ from urllib import urlencode
 from ConfigParser import SafeConfigParser
 
 
-VERSION = '1.4.1'
+VERSION = '1.4.2'
 
 
 def get_architecture():


### PR DESCRIPTION
changelog:

Includes bugfixes & enhancements since 1.4.1

* bootstrap.py again properly starts/stops services on EL6 (Fixes #213)
* bootstrap.py now allows graceful migrations from RHSM/SAM (Fixes #217)
* bootstrap.py now removes katello-host-tools when cleaning up the machine (Fixes #222)
* bootstrap.py now first removes the certs RPM before cleaning local cert files (Fixes #224 / Redmine #21132)