### PR TITLE
Capsule migration option, take 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ bootstrap Script for migrating existing running systems to Foreman with the Kate
 This script can take a system that is registered to Spacewalk, Satellite 5, Red Hat
 Network Classic and get it registered to Foreman & Katello.
 
+Optionally, you can also move systems between Capsules (both internal and
+external) of one Katello installation by using the `--new-capsule` option.
+
 # What does the Script do?
 
 * Identify which systems management platform is the system registered to (Classic/Sat5 or None)  then perform the following
@@ -20,6 +23,18 @@ Network Classic and get it registered to Foreman & Katello.
 * registering the system to Foreman
 * Configuring the system with a proper Puppet configuration pointing at Foreman
 * Removing/disabling old RHN Classic packages/daemons (rhnsd, osad, etc)
+
+## System already registered to a Foreman + Katello server / Capsule (--new-capsule)
+* Clean the existing Katello agent installation
+* Install the Katello consumer RPM for the target Foreman + Katello server / Capsule
+* Install the Katello agent software again, using the configuration for the
+  target Foreman + Katello / Capsule server
+* Make API calls to switch the system to a different hostgroup (optional)
+* Make API calls to update the Puppet master, Puppet CA, content source and
+  OpenSCAP proxy IDs (optional, except for content source)
+* Re-enable rhsmcertd
+* Update the Puppet configuration for the system to point to the right capsule (optional)
+* Restart Puppet and call for the user to go sign the CSR
 
 ## System not registered to any Red Hat Systems Management Platform:
 
@@ -168,6 +183,25 @@ By default, bootstrap.py does not delete the system's profile from the legacy pl
 ### Migrating a system from one Foreman + Katello installation to another.
 
 There are times where it is necessary to migrate clients from one Foreman + Katello installation to another. For instance, in lieu of upgrading an older Foreman + Katello installation, you choose to build a new installation in parallel. bootstrap.py can then be used to migrate clients from one Foreman + Katello installation to another. Simply provide the `--force` option, and bootstrap.py will remove the previous `katello-ca-consumer-*` package (from the old system), and will install the `katello-ca-consumer-*` package (from the new system), and continue registration as usual.
+
+### Migrating a system from one Foreman + Katello installation 6 or Capsule / to another in the same infrastructure
+
+In order to manually balance the load over multiple Capsule servers, you might
+want to move some existing systems to newly deployed Capsules. You can easily
+do this by running the bootstrap.py script like the examples below. Mind that
+you still have to manually revoke any Puppet certificates on the old capsules!
+
+~~~
+# ./bootstrap.py -l admin --new-capsule --server capsule.example.com
+~~~
+
+If you want to change the hostgroup and location of the system at the same
+time, run:
+
+~~~
+# ./bootstrap.py -l admin --new-capsule --server capsule.example.com \
+    --hostgroup mygroup --location mylocation
+~~~
 
 ### Enabling additional repositories at registration time.
 


### PR DESCRIPTION
So after a long pause, here's attempt two to bring in a capsule migration option into bootstrap.py.

Because the change is fairly large, here's the breakdown, to start with the nitty-gritty stuff:
- changes were required to basic functions, like `put_json` and `get_bootstrap_rpm`. The `put_json` function needed to accept a payload to update a host record, and the `get_bootstrap_rpm` needed to have options to override both whether or not to remove existing katello-ca-consumer RPMs, and whether or not to unregister when forcing the installation of new katello-ca-consumer RPMs. Unregistering, needless to say, from a migration PoV, would be bad.
- I also have added an `update_host_capsule_mapping` function to DRY when updating the proxy_ids for a system.
- Some obvious changes have been made to the parts of the script that provide help and figure out what to do with all the options.
- The part that does the actual migration is fairly long, that can't be helped much, I'm afraid. What happens is as follows:
  - get the new katello-ca-consumer from the target capsule and figure out the API_PORT, capsule_id, host_id and the features the capsule offers
  - optionally (depending on whether the `--hostgroup` and `--location` parameters are passed) switch to new location, hostgroup
  - optionally (depending on `puppet` and `foreman` in options.skip) change puppet_proxy_id and puppet_ca_proxy_id
  - optionally (depending on `foreman` in options.skip and the features the new capsule offers) change openscap_proxy_id
  - switch content_source_id
  - re-enable rhsmcertd
  - optionally, depending on options.skip, reconfigure Puppet

Remarks:
- Right now, I check for `foreman` and `puppet` in options.skip when changing puppet_proxy_id, puppet_ca_proxy_id and re-configuring Puppet. I don't think it makes sense to reconfigure Puppet if we skip foreman, because submitted reports will create / update an existing foreman host anyway. So if we skip `puppet` or `foreman`, we don't touch anything Puppet related. Agreed?
- We cannot check whether or not a host has an openscap_proxy_id configured through the API. Therefore, what I do is:
  - if we do not skip foreman and the capsule offers OpenSCAP, we set the openscap_proxy_id. After all, if we are staying in the same hostgroup and that hostgroup has OpenSCAP, we want to switch capsules. If we switch hostgroups to a hostgroup that has OpenSCAP, we want to switch capsules. If our hostgroup does not have OpenSCAP, setting the openscap_proxy_id doesn't matter.
  - if there is no openscap feature on the new capsule, we don't touch openscap_proxy_id, but warn the user. Same reasons as above. 

Sample usage is provided in README.md. Tested on RHEL6 and RHEL7 w/ Satellite 6.2.12. RHEL5 untested, but I'm not using any functionality in Python that wasn't available on Python 2.4 (I think).


