### PR TITLE
ensure sub-man installed before installing katello ca rpm

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -233,6 +233,9 @@ def get_bootstrap_rpm():
     if os.path.exists('/etc/pki/consumer/cert.pem'):
         print_generic('System appears to be registered via another entitlement server. Attempting unregister')
         unregister_system()
+
+    call_yum("install", "subscription-manager")
+
     if options.download_method == "https":
         print_generic("Writing custom cURL configuration to allow download via HTTPS without certificate verification")
         curl_config_dir = tempfile.mkdtemp()


### PR DESCRIPTION
the rpm requires it, but it might be not installed yet (like on plain CentOS)