### PR TITLE
Call 'yum clean all' when unregistering from another system. 

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -378,6 +378,8 @@ def register_systems(org_name, activationkey):
 
 def unregister_system():
     """Unregister the host using `subscription-manager`."""
+    print_generic("Cleaning old yum metadata")
+    call_yum("clean", "all")
     print_generic("Unregistering")
     exec_failok("/usr/sbin/subscription-manager unregister")
     exec_failok("/usr/sbin/subscription-manager clean")


### PR DESCRIPTION
Add a `yum clean all` to the `unregister_system()` function. Otherwise when registering, the client can potentially have yum metadata which references content that actually doesn't exist in the client's content view. 