### PR TITLE
Add a --force-content-source option

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,8 @@ Options:
   --skip-foreman        Do not create a Foreman host. Implies --skip-puppet.
                         When using --skip-foreman, you MUST pass the
                         Organization's LABEL, not NAME
+  --force-content-source
+                        Force the content source to be the registration capsule (it overrides the value in the host group if any is defined)
   --content-only        Setup host for content only. Alias to --skip foreman.
                         Implies --skip-puppet. When using --content-only, you
                         MUST pass the Organization's LABEL, not NAME


### PR DESCRIPTION
When creating a new host, in certain cases, we want to force the content source value to be the registration capsule.
As a matter of fact, satellite is not always setting this value, but it's needed in some remote execution configurations.
As discussed with @fcami it's usefull to workaround this bug : https://bugzilla.redhat.com/show_bug.cgi?id=1570808 

PS: I'm not respecting the too-many-statements pylint rule but I can't fix it without splitting the create_host function. As there are already some pylint exceptions in the code, let me know if you want me to add this one too, or if I need to split the function