### PR TITLE
fix(bootstrap): force lowercase FQDN writing puppet configuration

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -484,7 +484,7 @@ ca_server       = %s
 certname        = %s
 environment     = %s
 server          = %s
-""" % (main_section, options.puppet_ca_server, FQDN, puppet_env, options.puppet_server))
+""" % (main_section, options.puppet_ca_server, FQDN.lower(), puppet_env, options.puppet_server))
     if options.puppet_ca_port:
         puppet_conf.write("""ca_port         = %s
 """ % (options.puppet_ca_port))

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -473,6 +473,15 @@ ssldir = /etc/puppetlabs/puppet/ssl
         main_section += "digest_algorithm = sha256"
         print_generic("System is in FIPS mode. Setting digest_algorithm to SHA256 in puppet.conf")
     puppet_conf = open(puppet_conf_file, 'wb')
+
+    # set puppet.conf certname to lowercase FQDN, as capitalized characters would
+    # get translated anyway generating our certificate
+    # * https://puppet.com/docs/puppet/3.8/configuration.html#certname
+    # * https://puppet.com/docs/puppet/4.10/configuration.html#certname
+    # * https://puppet.com/docs/puppet/5.5/configuration.html#certname
+    # other links mentioning capitalized characters related issues:
+    # * https://grokbase.com/t/gg/puppet-users/152s27374y/forcing-a-variable-to-be-lower-case
+    # * https://groups.google.com/forum/#!topic/puppet-users/vRAu092ppzs
     puppet_conf.write("""
 %s
 [agent]


### PR DESCRIPTION
Registering production hosts to Katello, I noticed that when an
hostname has uppercase characters, then, puppet generates its
certificate translating my FQDN to lowercases. While puppet.conf
would still mention uppercases.
Eventually, puppet agent can't fetch its catalog (403 back from
puppetserver). Updating the certname value to match our certificate
fixes.

One could say that hostnames shouldn't include uppercase characters
to begin with.
On the other hand, I can't ask my customer to rename production hosts,
without being completely certain I'm not disturbing whatever application
their servers are running.

We could try setting `--fqdn`. Although having a fool-proof puppet
configuration might still be relevant (?)
Arguably, we could also patch FQDN default value (row 1012) to
`socket.getfqdn().lower()`, although I can't guarantee this won't
break something else. AFAIU, fixing puppet.conf is just what I need for
the bootstrap to execute properly on my customers servers.