### PR TITLE
Prepare 1.6.0 release of bootstrap. Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,21 @@ In the case the Puppet CA is running on a different server, you can use the `--p
     --puppet-server=puppet.example.com \
     --puppet-ca-port=8141
 ~~~
+
+### Adding a comment when registering a node.
+
+When registering a client, it is sometimes desirable to add a comment, denoting internal information such as the owner of the server or other site-specific info. This can be accomplished with the `--comment` option.
+
+~~~
+./bootstrap.py -l admin \
+    -s foreman.example.com \
+    -o "Red Hat" \
+    -L RDU \
+    -g "RHEL7/Crash" \
+    -a ak-Reg_To_Crash \
+    --comment 'Crash Testing Server'
+~~~
+
 # Help / Available options:
 
 ~~~
@@ -597,6 +612,8 @@ Options:
   -t timeout, --timeout=timeout
                         Timeout (in seconds) for API calls and subscription-
                         manager registration. Defaults to 900
+  -c COMMENT, --comment=COMMENT
+                        Add a host comment
 ~~~
 
 # Additional Notes

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -28,7 +28,7 @@ import rpm  # pylint:disable=import-error
 import rpmUtils.miscutils  # pylint:disable=import-error
 
 
-VERSION = '1.5.0'
+VERSION = '1.6.0'
 
 
 def get_architecture():


### PR DESCRIPTION
Release 1.6.0. 

Changelog

- (#254) Add a `--force-content-source` option. Useful when you have remote execution and hosts that may not have subnets defined. 
- (#252) Add a user-friendly comment
- (#250) Support Arbitrary servers as Puppet Master and Puppet CA, useful for load-balanced Puppet Masters. 
- (#249) bootstrap.py now verifies if the domain that a host is using is associated with the correct org/location. 
- (#246) adds a `--content-only` option as an alias to `--skip foreman`
- (#243) Allows a user to specify Location `-L` when using either `--content-only` or `--skip foreman`
- (#244) Documentation updates
- (#245) bootstrap.py now runs a `yum clean all` when unregistering from another server
- (#241) Updating the documentation for various `--skip` options. 
- (#216) implement pylint checking. 

