### PR TITLE
implement testing of python3 on fedora:29

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
+DOCKER=docker
 TEST_TARGETS=centos\:5 centos\:6 centos\:7
+TEST3_TARGETS=fedora\:29
 USE_SELINUX=$(shell test -d /sys/fs/selinux && echo ":Z")
 
-test: $(addprefix test-,$(TEST_TARGETS)) lint
+test: $(addprefix test-,$(TEST_TARGETS)) $(addprefix test3-,$(TEST3_TARGETS)) lint
 
 test-%:
-	docker run -it --volume $(CURDIR):/app$(USE_SELINUX) --workdir=/app $* python bootstrap.py --help
-	docker run -it --volume $(CURDIR):/app$(USE_SELINUX) --workdir=/app $* python setup.py sdist
+	$(DOCKER) run -it --volume $(CURDIR):/app$(USE_SELINUX) --workdir=/app $* python bootstrap.py --help
+	$(DOCKER) run -it --volume $(CURDIR):/app$(USE_SELINUX) --workdir=/app $* python setup.py sdist
+
+test3-%:
+	-$(DOCKER) run -it --volume $(CURDIR):/app$(USE_SELINUX) --workdir=/app $* python3 bootstrap.py --help
+	-$(DOCKER) run -it --volume $(CURDIR):/app$(USE_SELINUX) --workdir=/app $* python3 setup.py sdist
 
 lint:
-	python -m flake8 --ignore E501 ./bootstrap.py ./setup.py
+	python -m flake8 --ignore E501,W504 ./bootstrap.py ./setup.py
 	python -m pylint --reports=n --disable=I --ignore-imports=y ./bootstrap.py ./setup.py


### PR DESCRIPTION
the tests are currently executed, but the result is ignored as the code
is not yet fully python3 compatible

this patch also allows to override the Docker binary (to use Podman) and
adds W504 "line break after binary operator" to the flake8 ignore list