### PR TITLE
allow defining where to get ssh keys and where to store them

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,46 @@ cat ~/.ssh/authorized_keys
 ssh-rsa AAAAB3Nz.... foreman-proxy@foreman.example.com
 ~~~
 
+#### Fetching Remote Execution SSH keys from an URL
+
+~~~
+# ./bootstrap.py -l admin \
+    -s foreman.example.com \
+    -o "Red Hat" \
+    -L RDU \
+    -g "RHEL7/Crash" \
+    -a ak-Reg_To_Crash \
+    --rex \
+    --rex-urlkeyfile https://idm.example.com/users/root/keys
+~~~
+
+#### Fetching Remote Execution SSH keys from proxies
+
+~~~
+# ./bootstrap.py -l admin \
+    -s foreman.example.com \
+    -o "Red Hat" \
+    -L RDU \
+    -g "RHEL7/Crash" \
+    -a ak-Reg_To_Crash \
+    --rex \
+    --rex-proxies foreman.example.com,proxy01.example.com,proxy02.example.com
+~~~
+
+#### Deploying Remote Execution SSH keys to a non-default location
+
+~~~
+# ./bootstrap.py -l admin \
+    -s foreman.example.com \
+    -o "Red Hat" \
+    -L RDU \
+    -g "RHEL7/Crash" \
+    -a ak-Reg_To_Crash \
+    --rex \
+    --rex-user root \
+    --rex-authpath /etc/ssh/keys/root
+~~~
+
 ### Skipping particular steps:
 
 Sometimes, you may want to skip certain steps of the bootstrapping process. the `--skip` switch provides this. It currently has the following parameters
@@ -547,7 +587,9 @@ Options:
                         When using --skip-foreman, you MUST pass the
                         Organization's LABEL, not NAME
   --force-content-source
-                        Force the content source to be the registration capsule (it overrides the value in the host group if any is defined)
+                        Force the content source to be the registration
+                        capsule (it overrides the value in the host group if
+                        any is defined)
   --content-only        Setup host for content only. Alias to --skip foreman.
                         Implies --skip-puppet. When using --content-only, you
                         MUST pass the Organization's LABEL, not NAME
@@ -603,6 +645,16 @@ Options:
   --rex                 Install Foreman's SSH key for remote execution.
   --rex-user=REMOTE_EXEC_USER
                         Local user used by Foreman's remote execution feature.
+  --rex-proxies=REMOTE_EXEC_PROXIES
+                        Comma separated list of proxies to install Foreman's
+                        SSH keys for remote execution.
+  --rex-urlkeyfile=REMOTE_EXEC_URL
+                        HTTP/S location to install a file containing one or
+                        multiple Foreman's SSH keys for remote execution.
+  --rex-authpath=REMOTE_EXEC_AUTHPATH
+                        Full path to local authorized_keys file in order to
+                        install Foreman's SSH keys for remote execution.
+                        Default ~/.ssh/authorized_keys
   --enablerepos=enablerepos
                         Repositories to be enabled via subscription-manager -
                         comma separated


### PR DESCRIPTION
--rex-proxies: Comma separated list of Proxies to install Foreman's
SSH keys for remote execution. It will iterate all over the list of
capsules. If one fails user is notified by the task keeps going until
all proxies were tried.

--rex-urlkeyfile: HTTP/S location to install a file containing one or
multiple Foreman's SSH keys for remote execution. Instead of iterate
you can create file on /pub folder that contains all ssh public keys
of several capsules and tell bootstrap.py to fech it and install on
the local user authorized keys file.

--rex-authpath. Local folder where is placed the authorized_keys file
to install Foreman's SSH keys for remote execution. Default ~/.ssh.
I found that several customers specifies AuthorizedKeysFile on
sshd_config on a different path.

Closes: #204
Closes: #210 

Authored-by: Alberto Losada <alosadag@redhat.com>
Rebased-by: Evgeni Golov <evgeni@golov.de>
Rebased-by: François Cami <fcami@fedoraproject.org>