### PR TITLE
[RFE] add a capability in the bootstrap script to 'preserve proxy' when reconfiguring/migrating the client.

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -292,13 +292,13 @@ def is_fips():
 
 def get_rhsm_proxy():
     """
-    Save the proxy server settings from /etc/rhsm/rhsm.conf
+    Return the proxy server settings from /etc/rhsm/rhsm.conf as dictionary proxy_config.
     """
     rhsmconfig = SafeConfigParser()
     rhsmconfig.read('/etc/rhsm/rhsm.conf')
-    proxy_settings = [option for option in rhsmconfig.options('server') if option.startswith('proxy')]
-    saved_proxy_config = {setting: rhsmconfig.get('server', setting) for setting in proxy_settings}
-    return saved_proxy_config
+    proxy_options = [option for option in rhsmconfig.options('server') if option.startswith('proxy')]
+    proxy_config = {option: rhsmconfig.get('server', option) for option in proxy_options}
+    return proxy_config
 
 def set_rhsm_proxy(saved_proxy_config):
     """

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -290,6 +290,25 @@ def is_fips():
         fips_status = "0"
     return fips_status == "1"
 
+def get_rhsm_proxy():
+    """
+    Save the proxy server settings from /etc/rhsm/rhsm.conf
+    """
+    rhsmconfig = SafeConfigParser()
+    rhsmconfig.read('/etc/rhsm/rhsm.conf')
+    proxy_settings = [option for option in rhsmconfig.options('server') if option.startswith('proxy')]
+    saved_proxy_config = {setting: rhsmconfig.get('server', setting) for setting in proxy_settings}
+    return saved_proxy_config
+
+def set_rhsm_proxy(saved_proxy_config):
+    """
+    Set proxy server settings in /etc/rhsm/rhsm.conf from dictionary saved_proxy_config.
+    """
+    rhsmconfig = SafeConfigParser()
+    rhsmconfig.read('/etc/rhsm/rhsm.conf')
+    for option in saved_proxy_config.keys():
+        rhsmconfig.set('server', option, saved_proxy_config[option])
+    rhsmconfig.write(open('/etc/rhsm/rhsm.conf', 'w'))
 
 def get_bootstrap_rpm(clean=False, unreg=True):
     """
@@ -1097,6 +1116,7 @@ if __name__ == '__main__':
     parser.add_option("-t", "--timeout", dest="timeout", type="int", help="Timeout (in seconds) for API calls and subscription-manager registration. Defaults to %default", metavar="timeout", default=900)
     parser.add_option("-c", "--comment", dest="comment", help="Add a host comment")
     parser.add_option("--ignore-registration-failures", dest="ignore_registration_failures", action="store_true", help="Continue running even if registration via subscription-manager/rhn-migrate-classic-to-rhsm returns a non-zero return code.")
+    parser.add_option("--preserve-rhsm-proxy", dest="preserve_rhsm_proxy", help="Preserve proxy settings in /etc/rhsm/rhsm.conf when migrating RHSM -> RHSM")
     (options, args) = parser.parse_args()
 
     if options.no_foreman:
@@ -1214,6 +1234,7 @@ if __name__ == '__main__':
         print "PUPPET CA SERVER - %s" % options.puppet_ca_server
         print "PUPPET CA PORT - %s" % options.puppet_ca_port
         print "IGNORE REGISTRATION FAILURES - %s" % options.ignore_registration_failures
+        print "PRESERVE RHSM PROXY CONFIGURATION - %s" % options.preserve_rhsm_proxy
 
     # > Exit if the user isn't root.
     # Done here to allow an unprivileged user to run the script to see
@@ -1248,6 +1269,9 @@ if __name__ == '__main__':
     # > IF RHEL 5, not removing, and not moving to new capsule prepare the migration.
     if not options.remove and int(RELEASE[0]) == 5 and not options.new_capsule:
         prepare_rhel5_migration()
+
+    if options.preserve_rhsm_proxy:
+        saved_proxy_config = get_rhsm_proxy()
 
     if options.remove:
         # > IF remove, disassociate/delete host, unregister,
@@ -1366,6 +1390,8 @@ if __name__ == '__main__':
         if 'foreman' not in options.skip:
             create_host()
         configure_subscription_manager()
+        if options.preserve_rhsm_proxy:
+            set_rhsm_proxy(saved_proxy_config)
         register_systems(options.org, options.activationkey)
         if options.enablerepos:
             enable_repos()

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -290,6 +290,7 @@ def is_fips():
         fips_status = "0"
     return fips_status == "1"
 
+
 def get_rhsm_proxy():
     """
     Return the proxy server settings from /etc/rhsm/rhsm.conf as dictionary proxy_config.
@@ -297,21 +298,22 @@ def get_rhsm_proxy():
     rhsmconfig = SafeConfigParser()
     rhsmconfig.read('/etc/rhsm/rhsm.conf')
     proxy_options = [option for option in rhsmconfig.options('server') if option.startswith('proxy')]
-    #proxy_config = {option: rhsmconfig.get('server', option) for option in proxy_options}
     proxy_config = {}
     for option in proxy_options:
         proxy_config[option] = rhsmconfig.get('server', option)
     return proxy_config
 
-def set_rhsm_proxy(saved_proxy_config):
+
+def set_rhsm_proxy(proxy_config):
     """
     Set proxy server settings in /etc/rhsm/rhsm.conf from dictionary saved_proxy_config.
     """
     rhsmconfig = SafeConfigParser()
     rhsmconfig.read('/etc/rhsm/rhsm.conf')
-    for option in saved_proxy_config.keys():
-        rhsmconfig.set('server', option, saved_proxy_config[option])
+    for option in proxy_config.keys():
+        rhsmconfig.set('server', option, proxy_config[option])
     rhsmconfig.write(open('/etc/rhsm/rhsm.conf', 'w'))
+
 
 def get_bootstrap_rpm(clean=False, unreg=True):
     """

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -297,7 +297,10 @@ def get_rhsm_proxy():
     rhsmconfig = SafeConfigParser()
     rhsmconfig.read('/etc/rhsm/rhsm.conf')
     proxy_options = [option for option in rhsmconfig.options('server') if option.startswith('proxy')]
-    proxy_config = {option: rhsmconfig.get('server', option) for option in proxy_options}
+    #proxy_config = {option: rhsmconfig.get('server', option) for option in proxy_options}
+    proxy_config = {}
+    for option in proxy_options:
+        proxy_config[option] = rhsmconfig.get('server', option)
     return proxy_config
 
 def set_rhsm_proxy(saved_proxy_config):


### PR DESCRIPTION
This PR adds an option `--preserve-rhsm-proxy` which preserves the proxy settings in `/etc/rhsm/rhsm.conf`

This was originally requested in https://bugzilla.redhat.com/show_bug.cgi?id=1647631