### PR TITLE
release 1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,21 @@ When registering a client, it is sometimes desired to ignore registration failur
     --ignore-registration-failures
 ~~~
 
+### Preserving RHSM Proxy Settings
+
+When moving clients from RHSM to Katello or a different RHSM provider, the proxy settings in `/etc/rhsm/rhsm.conf` might get lost. Using `--preserve-rhsm-proxy` you can ensure that the old settings will be restored for the new configuration.
+
+
+~~~
+./bootstrap.py -l admin \
+    -s foreman.example.com \
+    -o "Red Hat" \
+    -L RDU \
+    -g "RHEL7/Crash" \
+    -a ak-Reg_To_Crash \
+    --preserve-rhsm-proxy
+~~~
+
 # Help / Available options:
 
 ~~~
@@ -684,6 +699,9 @@ Options:
                         Continue running even if registration via
                         subscription-manager/rhn-migrate-classic-to-rhsm
                         returns a non-zero return code.
+  --preserve-rhsm-proxy
+                        Preserve proxy settings in /etc/rhsm/rhsm.conf when
+                        migrating RHSM -> RHSM
 ~~~
 
 # Additional Notes

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -62,7 +62,7 @@ except ImportError:
 import rpm  # pylint:disable=import-error
 
 
-VERSION = '1.6.0'
+VERSION = '1.7.0'
 
 # Python 2.4 only supports octal numbers by prefixing '0'
 # Python 3 only support octal numbers by prefixing '0o'

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1190,7 +1190,7 @@ if __name__ == '__main__':
     parser.add_option("-t", "--timeout", dest="timeout", type="int", help="Timeout (in seconds) for API calls and subscription-manager registration. Defaults to %default", metavar="timeout", default=900)
     parser.add_option("-c", "--comment", dest="comment", help="Add a host comment")
     parser.add_option("--ignore-registration-failures", dest="ignore_registration_failures", action="store_true", help="Continue running even if registration via subscription-manager/rhn-migrate-classic-to-rhsm returns a non-zero return code.")
-    parser.add_option("--preserve-rhsm-proxy", dest="preserve_rhsm_proxy", help="Preserve proxy settings in /etc/rhsm/rhsm.conf when migrating RHSM -> RHSM")
+    parser.add_option("--preserve-rhsm-proxy", dest="preserve_rhsm_proxy", action="store_true", help="Preserve proxy settings in /etc/rhsm/rhsm.conf when migrating RHSM -> RHSM")
     (options, args) = parser.parse_args()
 
     if options.no_foreman:


### PR DESCRIPTION
this includes #285

 changelog:
  * Python 3 support
  * Capability to preserve proxy settings when reconfiguring/migrating the client (#283)
  * EL5 subscription manager compatibility fixes (#284)
  * Only yum clean metadata and dbcache, not RPMs (#280)
  * Allow defining where to get ssh keys and where to store them (#281)
  * Make the FIPS check more robust (#279)
  * Support yum and dnf Python bindings (#271)
  * Option to ignore registration failures (#261)
  * Force lowercase FQDN writing puppet configuration (#255)
  * Improve the error message when a search fails (#257)
