### PR TITLE
Add a --set-auto-attach option

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,8 @@ Options:
   --legacy-purge        Purge system from the Legacy environment (e.g. Sat5)
   -a ACTIVATIONKEY, --activationkey=ACTIVATIONKEY
                         Activation Key to register the system
+  --set-auto-attach     Set the content-host's auto-attach value to true or
+                        false
   -P, --skip-puppet     Do not install Puppet
   --skip-foreman        Do not create a Foreman host. Implies --skip-puppet.
                         When using --skip-foreman, you MUST pass the


### PR DESCRIPTION
In some cases we want to set the content-host's auto-attach value to false (or true).
This is different from the auto-attach value used in the activation key(s) which
is only used at registration time. If some auto-attach actions are triggered later on
it will use the content-host's auto-attach value

For example, with a satellite in "Organization Environment Access" we typically have no subscription attached to the content-host (auto-attach = false and no sub on the AK), but if the content-host's auto-attach is set to true, at the next rhsmcertd run on the client, it will pick a subscription. 
This as been discussed with the support in https://access.redhat.com/support/cases/#/case/02196634 and in bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=1676554 

NB: I have added some pylint exclusions for distutils.util module. The module is in python since at least 2.4.3 (tested on RH5.3) and pylint on my system is also happy with this import ...
