### PR TITLE
release 1.7.1

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -62,7 +62,7 @@ except ImportError:
 import rpm  # pylint:disable=import-error
 
 
-VERSION = '1.7.0'
+VERSION = '1.7.1'
 
 # Python 2.4 only supports octal numbers by prefixing '0'
 # Python 3 only support octal numbers by prefixing '0o'


### PR DESCRIPTION
* Bugfix for REX authorized_keys permission handling (#298)
* Improve error message and allow non-existing files for --rex-authpath (#299)
* Improve --rex-urlkeyfile help text (#293)
* Default bootstrap.py to install katello-host-tools and omit the katello-agent package (#258)
* Improve output when using the rex options (#291)
* Don't fail if yum clean fails (#289)
* Don't use json.loads to generate dicts (#288)
* Bugfix: don't build a newly created host (#287)
* Call rhn-migrate-classic-to-rhsm with --remove-rhn-packages (#137)
* Allow fetching REX keys from the API (#282)