### PR TITLE
Use platform-python on RHEL8 (#302)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ When using the `--legacy-purge` option, a user account on the legacy environment
 
 # Usage:
 
-On a RHEL8 host, call the bootstrap.py script as follows:
+On an EL8 (RHEL8, CentOS8, etc) host, there is no `/usr/bin/python` or `/usr/bin/python3` by default. The `bootstrap.py` script can be used with the `platform-python` as follows:
 ~~~
 # /usr/libexec/platform-python bootstrap.py
 ~~~

--- a/README.md
+++ b/README.md
@@ -113,7 +113,12 @@ When using the `--legacy-purge` option, a user account on the legacy environment
 * system group administrator for a system group that the system is a member of
 * granted permissions to the system explicitly via Users-> account-> 'Systems Administered by this User'
 
-# Usages:
+# Usage:
+
+On a RHEL8 host, call the bootstrap.py script as follows:
+~~~
+# /usr/libexec/platform-python bootstrap.py
+~~~
 
 ### Registering a system to Foreman + Katello
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ On an EL8 (RHEL8, CentOS8, etc) host, there is no `/usr/bin/python` or `/usr/bin
 ~~~
 # /usr/libexec/platform-python bootstrap.py
 ~~~
+When the `python36` module is installed, `/usr/bin/python3` can also be used.
 
 ### Registering a system to Foreman + Katello
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -5,6 +5,7 @@ or move it from Satellite 5 to 6.
 
 Use `pydoc ./bootstrap.py` to get the documentation.
 Use `awk -F'# >' 'NF>1 {print $2}' ./bootstrap.py` to see the flow.
+Use `/usr/libexec/platform-python bootstrap.py` on RHEL8
 """
 
 import getpass


### PR DESCRIPTION
/usr/libexec/platform-python bootstrap.py is the recommend way on RHEL8