### PR TITLE
Open file in 'w' mode instead of 'wb'

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -599,7 +599,7 @@ ssldir = /etc/puppetlabs/puppet/ssl
     if is_fips():
         main_section += "digest_algorithm = sha256"
         print_generic("System is in FIPS mode. Setting digest_algorithm to SHA256 in puppet.conf")
-    puppet_conf = open(puppet_conf_file, 'wb')
+    puppet_conf = open(puppet_conf_file, 'w')
 
     # set puppet.conf certname to lowercase FQDN, as capitalized characters would
     # get translated anyway generating our certificate


### PR DESCRIPTION
Issue on RHEL8: TypeError: a bytes-like object is required, not 'str'
We were trying to write binary where open() requires bytes
but we are trying to write str.

I have tested only on RHEL8. Expecting that this change will not break anything on other RHEL versions.