### PR TITLE
Release 1.7.5

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -63,7 +63,7 @@ except ImportError:
 import rpm  # pylint:disable=import-error
 
 
-VERSION = '1.7.4'
+VERSION = '1.7.5'
 
 # Python 2.4 only supports octal numbers by prefixing '0'
 # Python 3 only support octal numbers by prefixing '0o'


### PR DESCRIPTION
* BZ #1830884 - drop support for puppet < 4
* BZ #1802206 - document --legacy-purge not working on EL5