### PR TITLE
Release 1.7.6

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -63,7 +63,7 @@ except ImportError:
 import rpm  # pylint:disable=import-error
 
 
-VERSION = '1.7.5'
+VERSION = '1.7.6'
 
 # Python 2.4 only supports octal numbers by prefixing '0'
 # Python 3 only support octal numbers by prefixing '0o'


### PR DESCRIPTION
Changelog:
* don't try to create a VM when the hostgroup has a compute resource
  defined by forcing compute_resource to be None
* add a newline after the added REX key to play nicer with ssh-copy-id
* properly load dnf repo substitutions from /etc for Oracle Linux
* load dnf configuration as that might contain useful settings like
  proxies
* don't fail if sub-man-migration can't be installed (like on EL8)
* don't log bootstrap execution in the Ansible playbook