### PR TITLE
better handle setups without Puppet

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-python@v3
         if: matrix.target == 'lint'
       - name: Install
-        run: pip install flake8 pylint
+        run: pip install flake8 'pylint<2.13'
         if: matrix.target == 'lint'
       - name: Run tests
         run: make ${{ matrix.target }}


### PR DESCRIPTION
- check for "Puppet" feature when moving between proxies
- don't setup Puppet agent when no Puppet environment could be found